### PR TITLE
Extend feedback access

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/api/artemis/assessment/Result.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/api/artemis/assessment/Result.java
@@ -15,6 +15,12 @@ public class Result implements Serializable {
 	public int id;
 	@JsonProperty
 	public Date completionDate;
+	/**
+	 * {@code null} when accessed via
+	 * {@link edu.kit.kastel.sdq.artemis4j.api.client.ISubmissionsArtemisClient#getSubmissions()
+	 * ISubmissionsArtemisClient#getSubmissions()} and
+	 * {@link Submission#getLatestResult()}.
+	 */
 	@JsonProperty
 	public Feedback[] feedbacks;
 	@JsonProperty

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/api/artemis/assessment/Result.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/api/artemis/assessment/Result.java
@@ -18,7 +18,7 @@ public class Result implements Serializable {
 	/**
 	 * {@code null} when accessed via
 	 * {@link edu.kit.kastel.sdq.artemis4j.api.client.ISubmissionsArtemisClient#getSubmissions()
-	 * ISubmissionsArtemisClient#getSubmissions()} and
+	 * ISubmissionsArtemisClient#getSubmissions()} in combination with
 	 * {@link Submission#getLatestResult()}.
 	 */
 	@JsonProperty

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/api/artemis/assessment/Submission.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/api/artemis/assessment/Submission.java
@@ -36,6 +36,10 @@ public class Submission implements Serializable {
 		return this.participation.getParticipantIdentifier();
 	}
 
+	public Participation getParticipation() {
+		return this.participation;
+	}
+
 	public String getRepositoryUrl() {
 		String studentsUrl = this.participation.getRepositoryUrl();
 		String studentId = this.participation.getParticipantIdentifier();

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/api/client/IAssessmentArtemisClient.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/api/client/IAssessmentArtemisClient.java
@@ -6,6 +6,7 @@ import edu.kit.kastel.sdq.artemis4j.api.artemis.Exercise;
 import edu.kit.kastel.sdq.artemis4j.api.artemis.ExerciseStats;
 import edu.kit.kastel.sdq.artemis4j.api.artemis.assessment.*;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -54,9 +55,14 @@ public interface IAssessmentArtemisClient {
 	void saveAssessment(int participationId, boolean submit, AssessmentResult assessment) throws ArtemisClientException;
 
 	/**
-	 * Get statistics for exercise.
+	 * Get statistics of an exercise.
 	 */
 	ExerciseStats getStats(Exercise exercise) throws ArtemisClientException;
+
+	/**
+	 * Get the feedbacks of a result.
+	 */
+	List<Feedback> getFeedbacks(Submission submission, Result result) throws ArtemisClientException;
 
 	/**
 	 * Get the long feedback for a feedback.

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/client/AbstractArtemisClient.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/client/AbstractArtemisClient.java
@@ -30,6 +30,9 @@ public abstract class AbstractArtemisClient {
 	protected static final String EXERCISES_PATHPART = "exercises";
 	protected static final String COURSES_PATHPART = "courses";
 	protected static final String EXAMS_PATHPART = "exams";
+	protected static final String PARTICIPATIONS_PATHPART = "participations";
+	protected static final String RESULTS_PATHPART = "results";
+	protected static final String DETAILS_PATHPART = "details";
 
 	protected static final String COOKIE_NAME_JWT = "jwt";
 

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/client/AssessmentArtemisClient.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/client/AssessmentArtemisClient.java
@@ -17,6 +17,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 public class AssessmentArtemisClient extends AbstractArtemisClient implements IAssessmentArtemisClient {
@@ -141,6 +143,19 @@ public class AssessmentArtemisClient extends AbstractArtemisClient implements IA
 		} catch (IOException e) {
 			throw new ArtemisClientException(e.getMessage(), e);
 		}
+	}
+
+	@Override
+	public List<Feedback> getFeedbacks(Submission submission, Result result) throws ArtemisClientException {
+		Request request = new Request.Builder()
+				.url(this.path(PARTICIPATIONS_PATHPART, submission.getParticipation().getParticipationId(),
+						RESULTS_PATHPART, result.id, DETAILS_PATHPART))
+				.get().build();
+
+		Feedback[] feedbacksArray = this.call(this.client, request, Feedback[].class);
+		assert feedbacksArray != null;
+
+		return Arrays.asList(feedbacksArray);
 	}
 
 	@Override


### PR DESCRIPTION
The `Feedback` array in `Result` is `null` when fetched via `AssessmentArtemisClient`. This enables accessing all feedbacks without `LockResult`, i.e. without having to lock the submission. 