### PR TITLE
Fix `getSubmissions` not returning all submissions

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/api/client/ISubmissionsArtemisClient.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/api/client/ISubmissionsArtemisClient.java
@@ -32,15 +32,25 @@ public interface ISubmissionsArtemisClient {
 
 	/**
 	 * Get all submissions for the given exercise and correction round.
-	 * 
+	 *
 	 * @return submissions for the given exercise and correction round.
 	 * @throws ArtemisClientException if some errors occur while parsing the result.
 	 */
-	List<Submission> getSubmissions(Exercise exercise, int correctionRound) throws ArtemisClientException;
+	default List<Submission> getSubmissions(Exercise exercise, int correctionRound) throws ArtemisClientException {
+		return this.getSubmissions(exercise, correctionRound, false);
+	}
+
+	/**
+	 * Get all submissions for the given exercise and correction round.
+	 *
+	 * @return submissions for the given exercise and correction round.
+	 * @throws ArtemisClientException if some errors occur while parsing the result.
+	 */
+	List<Submission> getSubmissions(Exercise exercise, int correctionRound, boolean filterAssessedByTutor) throws ArtemisClientException;
 
 	/**
 	 * Get submission with submissionId for the given exercise.
-	 * 
+	 *
 	 * @param exercise     exercise to load submission.
 	 * @param submissionId of submission to be returned
 	 * @return submission with submissionId.

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/api/client/ISubmissionsArtemisClient.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/api/client/ISubmissionsArtemisClient.java
@@ -36,9 +36,7 @@ public interface ISubmissionsArtemisClient {
 	 * @return submissions for the given exercise and correction round.
 	 * @throws ArtemisClientException if some errors occur while parsing the result.
 	 */
-	default List<Submission> getSubmissions(Exercise exercise, int correctionRound) throws ArtemisClientException {
-		return this.getSubmissions(exercise, correctionRound, false);
-	}
+	List<Submission> getSubmissions(Exercise exercise, int correctionRound) throws ArtemisClientException;
 
 	/**
 	 * Get all submissions for the given exercise and correction round.

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/client/SubmissionsArtemisClient.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/client/SubmissionsArtemisClient.java
@@ -17,20 +17,21 @@ public class SubmissionsArtemisClient extends AbstractArtemisClient implements I
 	private final OkHttpClient client;
 	private final User assessor;
 	private final IFeedbackClient feedbackClient;
+	private final boolean filterAssessedByTutor;
 
 	public SubmissionsArtemisClient(final String hostname, String token, User assessor, IFeedbackClient feedbackClient) {
 		super(hostname);
 		this.client = this.createClient(token);
 		this.assessor = assessor;
 		this.feedbackClient = feedbackClient;
+		this.filterAssessedByTutor = false;
 	}
 
 	@Override
 	public List<Submission> getSubmissions(Exercise exercise, int correctionRound) throws ArtemisClientException {
-		boolean isInstructor = exercise.getCourse().isInstructor(this.assessor);
 		Request request = new Request.Builder() //
 				.url(this.path(EXERCISES_PATHPART, exercise.getExerciseId(), PROGRAMMING_SUBMISSIONS_PATHPART).newBuilder()
-						.addQueryParameter("assessedByTutor", String.valueOf(!isInstructor))
+						.addQueryParameter("assessedByTutor", String.valueOf(filterAssessedByTutor))
 						.addQueryParameter("correction-round", String.valueOf(correctionRound)).build())
 				.get().build();
 

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/client/SubmissionsArtemisClient.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/client/SubmissionsArtemisClient.java
@@ -17,18 +17,16 @@ public class SubmissionsArtemisClient extends AbstractArtemisClient implements I
 	private final OkHttpClient client;
 	private final User assessor;
 	private final IFeedbackClient feedbackClient;
-	private final boolean filterAssessedByTutor;
 
 	public SubmissionsArtemisClient(final String hostname, String token, User assessor, IFeedbackClient feedbackClient) {
 		super(hostname);
 		this.client = this.createClient(token);
 		this.assessor = assessor;
 		this.feedbackClient = feedbackClient;
-		this.filterAssessedByTutor = false;
 	}
 
 	@Override
-	public List<Submission> getSubmissions(Exercise exercise, int correctionRound) throws ArtemisClientException {
+	public List<Submission> getSubmissions(Exercise exercise, int correctionRound, boolean filterAssessedByTutor) throws ArtemisClientException {
 		Request request = new Request.Builder() //
 				.url(this.path(EXERCISES_PATHPART, exercise.getExerciseId(), PROGRAMMING_SUBMISSIONS_PATHPART).newBuilder()
 						.addQueryParameter("assessedByTutor", String.valueOf(filterAssessedByTutor))

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/client/SubmissionsArtemisClient.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/client/SubmissionsArtemisClient.java
@@ -26,6 +26,11 @@ public class SubmissionsArtemisClient extends AbstractArtemisClient implements I
 	}
 
 	@Override
+	public List<Submission> getSubmissions(Exercise exercise, int correctionRound) throws ArtemisClientException {
+		return this.getSubmissions(exercise, correctionRound, !exercise.getCourse().isInstructor(this.assessor));
+	}
+
+	@Override
 	public List<Submission> getSubmissions(Exercise exercise, int correctionRound, boolean filterAssessedByTutor) throws ArtemisClientException {
 		Request request = new Request.Builder() //
 				.url(this.path(EXERCISES_PATHPART, exercise.getExerciseId(), PROGRAMMING_SUBMISSIONS_PATHPART).newBuilder()


### PR DESCRIPTION
Artemis allows non-instructors to fetch all submissions and not only the ones assessed by the tutor (with this change tutors will be able to use https://github.com/kit-sdq/programming-lecture-artemis-score-stats).

The original python API had this method signature for the endpoint:
```python
    async def get_submissions(
        self,
        exercise_id: int,
        filter_submitted_only: bool = False,
        filter_assessed_by_tutor: bool = False,
        correction_round: int = 0,
    ) -> AsyncGenerator[ProgrammingSubmission, None]:
```
which allowed the caller to specify the options for the endpoint.

I tried to replicate the same behaviour for the Java API. The Javadoc of `getSubmissions` does not gurantee that the returned submissions are only those assessed by a tutor:
```java
	/**
	 * Get all submissions for the given exercise and correction round.
	 *
	 * @return submissions for the given exercise and correction round.
	 * @throws ArtemisClientException if some errors occur while parsing the result.
	 */
```
Therefore I changed the default to `false`, so it really returns "all submissions".