### PR TITLE
Limit concurrency between workflow runs

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -20,7 +20,6 @@ env:
 
 concurrency:
   group: artemis-test-system
-  cancel-in-progress: true
 
 jobs:
   pre_job:

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -18,6 +18,10 @@ env:
   EXAM_EXERCISE_GROUP_ID: "6"
   EXAM_PROGRAMMING_EXERCISE_ID: "48"
 
+concurrency:
+  group: artemis-test-system
+  cancel-in-progress: true
+
 jobs:
   pre_job:
     name: "Check for duplicate jobs"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,10 @@ env:
   EXAM_EXERCISE_GROUP_ID: "6"
   EXAM_PROGRAMMING_EXERCISE_ID: "48"
 
+concurrency:
+  group: artemis-test-system
+  cancel-in-progress: true
+
 jobs:
   pre_job:
     name: "Check for duplicate jobs"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,6 @@ env:
 
 concurrency:
   group: artemis-test-system
-  cancel-in-progress: true
 
 jobs:
   pre_job:

--- a/.github/workflows/maven-manual-release.yml
+++ b/.github/workflows/maven-manual-release.yml
@@ -26,7 +26,6 @@ env:
 
 concurrency:
   group: artemis-test-system
-  cancel-in-progress: true
         
 jobs:
     build:

--- a/.github/workflows/maven-manual-release.yml
+++ b/.github/workflows/maven-manual-release.yml
@@ -23,6 +23,10 @@ env:
   EXAM_ID: "5"
   EXAM_EXERCISE_GROUP_ID: "6"
   EXAM_PROGRAMMING_EXERCISE_ID: "48"
+
+concurrency:
+  group: artemis-test-system
+  cancel-in-progress: true
         
 jobs:
     build:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,6 +23,10 @@ env:
   EXAM_EXERCISE_GROUP_ID: "6"
   EXAM_PROGRAMMING_EXERCISE_ID: "48"
 
+concurrency:
+  group: artemis-test-system
+  cancel-in-progress: true
+
 jobs:
   pre_job:
     name: "Check for duplicate jobs"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,7 +25,6 @@ env:
 
 concurrency:
   group: artemis-test-system
-  cancel-in-progress: true
 
 jobs:
   pre_job:


### PR DESCRIPTION
This should work around Artemis' concurrency bug, where Artemis loses test results when submitting multiple results for the same submission at the same time