### PR TITLE
Run spotless in CI and split chained method calls over multiple lines.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
-          
+
   build:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
@@ -48,7 +48,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: joshlong/java-version-export-github-action@v28
-      id: jve   
+      id: jve
 
     - name: Java with Cache
       uses: actions/setup-java@v4
@@ -59,6 +59,6 @@ jobs:
 
     - name: Maven Verify
       shell: bash
-      run: mvn -U -B verify
-
-
+      run: |
+        git fetch origin main # necessary for spotless
+        mvn -U -B verify

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,15 @@
           </pom>
           <ratchetFrom>origin/main</ratchetFrom>
         </configuration>
+        <executions>
+          <execution>
+            <id>spotless:check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Right now, the formatting changes lines like this
![image](https://github.com/user-attachments/assets/8574bb10-3914-41c7-adda-96a49b644eb9)
to this
![image](https://github.com/user-attachments/assets/5e5e36db-32a6-449d-9798-56d19265a687)

(which is not ideal).

This PR fixes that issue. I will rebase this PR/apply the formatting to all files soon