### PR TITLE
Fix missing lock in UtilitiesTest & set the number of test cases when submitting results

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/client/ResultDTO.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/client/ResultDTO.java
@@ -29,11 +29,29 @@ public record ResultDTO(
         @JsonProperty Boolean rated,
         @JsonProperty List<FeedbackDTO> feedbacks,
         @JsonProperty UserDTO assessor,
-        @JsonProperty AssessmentType assessmentType) {
+        @JsonProperty AssessmentType assessmentType,
+        @JsonProperty int testCaseCount,
+        @JsonProperty int passedTestCaseCount,
+        @JsonProperty int codeIssueCount) {
 
+    /**
+     * BE WARNED: This method takes the (passed) test case count from the lockingResult. It does NOT recalculate it from the feedbacks!
+     * Should you for any reason change the test result, DO NOT USE THIS METHOD!
+     */
     public static ResultDTO forAssessmentSubmission(
-            long submissionId, double score, List<FeedbackDTO> feedbacks, UserDTO assessor) {
-        return new ResultDTO(submissionId, null, true, score, true, feedbacks, assessor, AssessmentType.SEMI_AUTOMATIC);
+            long submissionId, double score, List<FeedbackDTO> feedbacks, ResultDTO lockingResult) {
+        return new ResultDTO(
+                submissionId,
+                null,
+                true,
+                score,
+                true,
+                feedbacks,
+                lockingResult.assessor(),
+                AssessmentType.SEMI_AUTOMATIC,
+                lockingResult.testCaseCount(),
+                lockingResult.passedTestCaseCount(),
+                lockingResult.codeIssueCount());
     }
 
     private static List<FeedbackDTO> fetchFeedbacks(ArtemisClient client, long resultId, long participationId)

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Assessment.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Assessment.java
@@ -53,6 +53,7 @@ public class Assessment extends ArtemisConnectionHolder {
             new MessageFormat("    * Note:" + " The sum of penalties hit the limits for this rating group."));
     private static final FormatString NO_FEEDBACK_DUMMY = new FormatString("The tutor has made no annotations.");
 
+    private final ResultDTO lockingResult;
     private final List<Annotation> annotations;
     private final List<TestResult> testResults;
     private final ProgrammingSubmission programmingSubmission;
@@ -74,6 +75,7 @@ public class Assessment extends ArtemisConnectionHolder {
             Locale studentLocale)
             throws AnnotationMappingException, ArtemisNetworkException {
         super(programmingSubmission);
+        this.lockingResult = result;
         this.programmingSubmission = programmingSubmission;
         this.config = config;
         this.correctionRound = correctionRound;
@@ -357,10 +359,7 @@ public class Assessment extends ArtemisConnectionHolder {
         double absoluteScore = this.calculateTotalPoints();
         double relativeScore = absoluteScore / this.getMaxPoints() * 100.0;
         ResultDTO result = ResultDTO.forAssessmentSubmission(
-                this.programmingSubmission.getId(),
-                relativeScore,
-                feedbacks,
-                this.getConnection().getAssessor().toDTO());
+                this.programmingSubmission.getId(), relativeScore, feedbacks, this.lockingResult);
 
         // Sanity check
         double feedbackPoints = Math.min(


### PR DESCRIPTION
Without the latter, the Artemis UI displays something like "no test cases executed", even though the test cases are clearly visible when clicking on the result.