### PR TITLE
Implement annotation merging #41

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <jackson.version>2.17.2</jackson.version>
     <slf4j.version>2.0.16</slf4j.version>
     <okhttp.version>4.12.0</okhttp.version>
-    <autograder.version>0.6.1</autograder.version>
+    <autograder.version>0.6.2</autograder.version>
     <jgit.version>7.0.0.202409031743-r</jgit.version>
     <junit.version>5.11.0</junit.version>
     <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Annotation.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Annotation.java
@@ -1,6 +1,8 @@
 /* Licensed under EPL-2.0 2024. */
 package edu.kit.kastel.sdq.artemis4j.grading;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -24,6 +26,17 @@ public final class Annotation {
     private final AnnotationSource source;
     private String customMessage;
     private Double customScore;
+    // If not empty, this list contains classifiers that are used to group annotations.
+    // For example, all annotations that are related, could have the classifier ["a"],
+    // then they would be grouped together.
+    //
+    // You can add further classifiers to group annotations in a more fine-grained way:
+    // For example, when you have annotations with the classifiers ["a", "b"]
+    // and ["a", "c"], then if there are more than "annotationLimit"
+    // with the classifier "a", it would merge all annotations with the classifiers ["a", "b"]
+    // and all annotations with the classifiers ["a", "c"].
+    private final List<String> classifiers;
+    private final Optional<Integer> annotationLimit;
 
     /**
      * Deserializes an annotation from its metajson format
@@ -37,6 +50,8 @@ public final class Annotation {
         this.source = dto.source() != null ? dto.source() : AnnotationSource.UNKNOWN;
         this.customMessage = dto.customMessageForJSON();
         this.customScore = dto.customPenaltyForJSON();
+        this.classifiers = dto.classifiers();
+        this.annotationLimit = Optional.ofNullable(dto.annotationLimit());
     }
 
     Annotation(
@@ -47,6 +62,19 @@ public final class Annotation {
             String customMessage,
             Double customScore,
             AnnotationSource source) {
+        this(mistakeType, filePath, startLine, endLine, customMessage, customScore, source, List.of(), null);
+    }
+
+    Annotation(
+            MistakeType mistakeType,
+            String filePath,
+            int startLine,
+            int endLine,
+            String customMessage,
+            Double customScore,
+            AnnotationSource source,
+            List<String> classifiers,
+            Integer annotationLimit) {
         // Validate custom penalty and message
         if (mistakeType.isCustomAnnotation()) {
             if (customScore == null) {
@@ -67,6 +95,8 @@ public final class Annotation {
         this.customMessage = customMessage;
         this.customScore = customScore;
         this.source = source;
+        this.classifiers = new ArrayList<>(classifiers);
+        this.annotationLimit = Optional.ofNullable(annotationLimit);
     }
 
     /**
@@ -135,6 +165,26 @@ public final class Annotation {
     }
 
     /**
+     * Returns the classifiers of this annotation that can be used to group annotations.
+     *
+     * @return a list of classifiers
+     */
+    public List<String> getClassifiers() {
+        return new ArrayList<>(this.classifiers);
+    }
+
+    /**
+     * Returns the maximum number of annotations that should be displayed if one or more classifiers match.
+     * <p>
+     * It is up to the implementation, how the limit is applied in case of multiple classifiers.
+     *
+     * @return the maximum number of annotations that should be displayed
+     */
+    public Optional<Integer> getAnnotationLimit() {
+        return this.annotationLimit;
+    }
+
+    /**
      * The custom score associated with this message, if any. Is always empty for
      * predefined annotations, and never empty for custom annotations.
      */
@@ -161,7 +211,17 @@ public final class Annotation {
      * Serializes this annotation to its metajson format
      */
     public AnnotationDTO toDTO() {
-        return new AnnotationDTO(uuid, type.getId(), startLine, endLine, filePath, customMessage, customScore, source);
+        return new AnnotationDTO(
+                uuid,
+                type.getId(),
+                startLine,
+                endLine,
+                filePath,
+                customMessage,
+                customScore,
+                source,
+                classifiers,
+                annotationLimit.orElse(null));
     }
 
     @Override

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Annotation.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Annotation.java
@@ -36,7 +36,7 @@ public final class Annotation {
     // with the classifier "a", it would merge all annotations with the classifiers ["a", "b"]
     // and all annotations with the classifiers ["a", "c"].
     private final List<String> classifiers;
-    private final Optional<Integer> annotationLimit;
+    private final Integer annotationLimit;
 
     /**
      * Deserializes an annotation from its metajson format
@@ -51,7 +51,7 @@ public final class Annotation {
         this.customMessage = dto.customMessageForJSON();
         this.customScore = dto.customPenaltyForJSON();
         this.classifiers = dto.classifiers();
-        this.annotationLimit = Optional.ofNullable(dto.annotationLimit());
+        this.annotationLimit = dto.annotationLimit();
     }
 
     Annotation(
@@ -96,7 +96,7 @@ public final class Annotation {
         this.customScore = customScore;
         this.source = source;
         this.classifiers = new ArrayList<>(classifiers);
-        this.annotationLimit = Optional.ofNullable(annotationLimit);
+        this.annotationLimit = annotationLimit;
     }
 
     /**
@@ -181,7 +181,7 @@ public final class Annotation {
      * @return the maximum number of annotations that should be displayed
      */
     public Optional<Integer> getAnnotationLimit() {
-        return this.annotationLimit;
+        return Optional.ofNullable(this.annotationLimit);
     }
 
     /**
@@ -221,7 +221,7 @@ public final class Annotation {
                 customScore,
                 source,
                 classifiers,
-                annotationLimit.orElse(null));
+                annotationLimit);
     }
 
     @Override

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/AnnotationMerger.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/AnnotationMerger.java
@@ -17,11 +17,9 @@ import edu.kit.kastel.sdq.artemis4j.i18n.FormatString;
  * Merges annotations based on their classifiers.
  */
 final class AnnotationMerger {
-    // TODO: where should the translations be stored?
     private static final FormatString MERGED_ANNOTATIONS_FORMAT = new FormatString(
-            // TODO: should default locale be English or German?
-            new MessageFormat("{0}Other problems in {1}.", Locale.ENGLISH),
-            Map.of(Locale.GERMAN, new MessageFormat("{0}Weitere Probleme in {1}.", Locale.GERMAN)));
+            new MessageFormat("{0}Weitere Probleme in {1}.", Locale.GERMAN),
+            Map.of(Locale.ENGLISH, new MessageFormat("{0}Other problems in {1}.", Locale.ENGLISH)));
 
     private AnnotationMerger() {}
 
@@ -45,15 +43,7 @@ final class AnnotationMerger {
         // first group all problems by the first classifier:
         Map<String, List<Annotation>> groupedAnnotations = unreducedAnnotations.stream()
                 .collect(Collectors.groupingBy(
-                        annotation -> {
-                            List<String> classifiers = annotation.getClassifiers();
-                            if (classifiers.isEmpty()) {
-                                // do not merge annotations without a classifier:
-                                return annotation.getUUID();
-                            } else {
-                                return classifiers.get(0);
-                            }
-                        },
+                        annotation -> annotation.getClassifiers().stream().findFirst().orElse(annotation.getUUID()),
                         LinkedHashMap::new,
                         Collectors.toList()));
 

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/AnnotationMerger.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/AnnotationMerger.java
@@ -1,0 +1,186 @@
+/* Licensed under EPL-2.0 2024. */
+package edu.kit.kastel.sdq.artemis4j.grading;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+import edu.kit.kastel.sdq.artemis4j.i18n.FormatString;
+
+/**
+ * Merges annotations based on their classifiers.
+ */
+final class AnnotationMerger {
+    // TODO: where should the translations be stored?
+    private static final FormatString MERGED_ANNOTATIONS_FORMAT = new FormatString(
+            // TODO: should default locale be English or German?
+            new MessageFormat("{0}Other problems in {1}.", Locale.ENGLISH),
+            Map.of(Locale.GERMAN, new MessageFormat("{0}Weitere Probleme in {1}.", Locale.GERMAN)));
+
+    private AnnotationMerger() {}
+
+    /**
+     * Merges annotations based on their classifiers or not if they have none.
+     * <p>
+     * This method assumes that the annotation uuids are unique.
+     *
+     * @param unreducedAnnotations the list of annotations to merge
+     * @param upperAnnotationLimit the maximum number of annotations for the first classifier
+     * @param locale the locale to use for the format string
+     * @return the merged list of annotations
+     */
+    static List<Annotation> mergeAnnotations(
+            Collection<Annotation> unreducedAnnotations, int upperAnnotationLimit, Locale locale) {
+        // -1 means no limit (useful for unit tests, where one wants to see all annotations)
+        if (upperAnnotationLimit == -1) {
+            return new ArrayList<>(unreducedAnnotations);
+        }
+
+        // first group all problems by the first classifier:
+        Map<String, List<Annotation>> groupedAnnotations = unreducedAnnotations.stream()
+                .collect(Collectors.groupingBy(
+                        annotation -> {
+                            List<String> classifiers = annotation.getClassifiers();
+                            if (classifiers.isEmpty()) {
+                                // do not merge annotations without a classifier:
+                                return annotation.getUUID();
+                            } else {
+                                return classifiers.get(0);
+                            }
+                        },
+                        LinkedHashMap::new,
+                        Collectors.toList()));
+
+        List<Annotation> result = new ArrayList<>();
+        for (List<Annotation> annotationsForClassifier : groupedAnnotations.values()) {
+            // if the annotation limit is set, use it (if it does not exceed the upper limit),
+            // otherwise use the upper limit
+            int targetNumberOfAnnotations = Math.min(
+                    upperAnnotationLimit,
+                    annotationsForClassifier.get(0).getAnnotationLimit().orElse(upperAnnotationLimit));
+
+            if (annotationsForClassifier.size() <= targetNumberOfAnnotations) {
+                result.addAll(annotationsForClassifier);
+                continue;
+            }
+
+            // Further partition the annotations by their remaining classifiers:
+            annotationsForClassifier.stream()
+                    .collect(Collectors.groupingBy(
+                            annotation -> {
+                                List<String> classifiers = annotation.getClassifiers();
+                                if (classifiers.size() <= 1) {
+                                    return annotation.getUUID();
+                                } else {
+                                    // to simplify the grouping code, we merge the remaining classifiers
+                                    // into a single string
+                                    return String.join(" ", classifiers.subList(1, classifiers.size()));
+                                }
+                            },
+                            LinkedHashMap::new,
+                            Collectors.toList()))
+                    .values()
+                    .stream()
+                    .flatMap(list -> merge(list, targetNumberOfAnnotations, locale).stream())
+                    .forEach(result::add);
+        }
+
+        return result;
+    }
+
+    private static List<Annotation> merge(List<Annotation> annotations, int limit, Locale locale) {
+        // use a dumb algorithm: keep the first limit - 1 annotations, and merge the remainder into a single annotation
+        if (annotations.size() <= limit) {
+            return annotations;
+        }
+
+        List<Annotation> result = new ArrayList<>(annotations.subList(0, limit - 1));
+        List<Annotation> toMerge = annotations.subList(limit - 1, annotations.size());
+
+        // first we try to find an annotation with a custom message, this is the main one that will be shown to the user
+        int firstIndexWithCustomMessage = 0;
+        for (int i = 0; i < toMerge.size(); i++) {
+            if (toMerge.get(i).getCustomMessage().isPresent()) {
+                firstIndexWithCustomMessage = i;
+                break;
+            }
+        }
+
+        // the first annotation with the custom message is removed, so it doesn't appear twice
+        Annotation firstAnnotation = toMerge.remove(firstIndexWithCustomMessage);
+        // if there are no annotations with a custom message, the firstIndexWithCustomMessage will be 0,
+        // and because it doesn't have a custom message it will be null
+        String message = firstAnnotation.getCustomMessage().orElse(null);
+        if (message == null) {
+            message = "";
+        } else {
+            // some messages might not end with a period, which would look weird with the above format string,
+            // so this adds one if necessary
+            if (!message.endsWith(".")) {
+                message += ".";
+            }
+
+            message += " ";
+        }
+
+        String customMessage = MERGED_ANNOTATIONS_FORMAT
+                .format(message, displayLocations(firstAnnotation, toMerge))
+                .translateTo(locale);
+
+        result.add(new Annotation(
+                firstAnnotation.getMistakeType(),
+                firstAnnotation.getFilePath(),
+                firstAnnotation.getStartLine(),
+                firstAnnotation.getEndLine(),
+                customMessage,
+                firstAnnotation.getCustomScore().orElse(null),
+                firstAnnotation.getSource()));
+
+        return result;
+    }
+
+    private static String displayLocations(Annotation first, Collection<Annotation> others) {
+        Map<String, List<Annotation>> positionsByFile = others.stream()
+                .collect(Collectors.groupingBy(Annotation::getFilePath, LinkedHashMap::new, Collectors.toList()));
+
+        // if all annotations are in the same file, we don't need to display the filename
+        boolean withoutFilename = positionsByFile.size() == 1 && positionsByFile.containsKey(first.getFilePath());
+
+        StringJoiner joiner = new StringJoiner(", ");
+        // Format should look like this: File:(L1, L2, L3), File2:(L4, L5), File3:L5
+        for (Map.Entry<String, List<Annotation>> entry : positionsByFile.entrySet()) {
+            String path = entry.getKey();
+            List<Annotation> filePositions = entry.getValue();
+
+            String lines = filePositions.stream()
+                    .map(position -> "L%d".formatted(position.getStartLine()))
+                    .collect(Collectors.joining(", "));
+
+            if (filePositions.size() > 1 && !withoutFilename) {
+                lines = "(%s)".formatted(lines);
+            }
+
+            if (withoutFilename) {
+                joiner.add(lines);
+                continue;
+            }
+
+            joiner.add("%s:%s".formatted(getFilenameWithoutExtension(path), lines));
+        }
+
+        return joiner.toString();
+    }
+
+    private static String getFilenameWithoutExtension(String path) {
+        String[] parts = path.split("[\\\\\\/]");
+        String file = parts[parts.length - 1];
+
+        return file.split("\\.")[0];
+    }
+}

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Assessment.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Assessment.java
@@ -35,7 +35,7 @@ public class Assessment extends ArtemisConnectionHolder {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(Assessment.class);
 
     // TODO: should this be exposed/configurable by artemis4j users?
-    private static final int DEFAULT_ANNOTATION_LIMIT = 8;
+    private static final int DEFAULT_ANNOTATION_LIMIT = 12;
     private static final FormatString MANUAL_FEEDBACK = new FormatString(new MessageFormat("[{0}:{1}] {2}"));
     private static final FormatString MANUAL_FEEDBACK_CUSTOM_EXP =
             new FormatString(new MessageFormat("[{0}:{1}] " + "{2}\nExplanation: {3}"));

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Assessment.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Assessment.java
@@ -34,7 +34,6 @@ import org.slf4j.Logger;
 public class Assessment extends ArtemisConnectionHolder {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(Assessment.class);
 
-    // TODO: should this be exposed/configurable by artemis4j users?
     private static final int DEFAULT_ANNOTATION_LIMIT = 12;
     private static final FormatString MANUAL_FEEDBACK = new FormatString(new MessageFormat("[{0}:{1}] {2}"));
     private static final FormatString MANUAL_FEEDBACK_CUSTOM_EXP =

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/ProgrammingSubmission.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/ProgrammingSubmission.java
@@ -187,7 +187,13 @@ public class ProgrammingSubmission extends ArtemisConnectionHolder {
         return Objects.hashCode(this.getId());
     }
 
-    private Optional<ResultDTO> getRelevantResult() {
+    // TODO: Can I replace getLatestResult with getRelevantResult?
+    /**
+     * Returns the relevant result for this submission (should be the latest result).
+     *
+     * @return the relevant result, if present
+     */
+    public Optional<ResultDTO> getRelevantResult() {
         var results = this.dto.nonAutomaticResults();
 
         if (results.isEmpty()) {

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/ProgrammingSubmission.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/ProgrammingSubmission.java
@@ -187,9 +187,13 @@ public class ProgrammingSubmission extends ArtemisConnectionHolder {
         return Objects.hashCode(this.getId());
     }
 
-    // TODO: Can I replace getLatestResult with getRelevantResult?
     /**
-     * Returns the relevant result for this submission (should be the latest result).
+     * Returns the relevant result for this submission.
+     * <p>
+     * The difference between this method and {@link #getLatestResult()} is that
+     * when a submission has multiple results from different correction rounds, this
+     * method will return the result for the current correction round. If you want the
+     * latest result regardless of the correction round, use {@link #getLatestResult()}.
      *
      * @return the relevant result, if present
      */

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/autograder/AutograderRunner.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/autograder/AutograderRunner.java
@@ -8,6 +8,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import de.firemage.autograder.api.AbstractLinter;
+import de.firemage.autograder.api.AbstractProblem;
 import de.firemage.autograder.api.CheckConfiguration;
 import de.firemage.autograder.api.JavaVersion;
 import de.firemage.autograder.api.LinterException;
@@ -65,7 +66,7 @@ public final class AutograderRunner {
                     checkConfiguration,
                     statusConsumerWrapper);
 
-            for (var problem : problems) {
+            for (AbstractProblem problem : problems) {
                 var mistakeType = problemTypesMap.get(problem.getType());
                 var position = problem.getPosition();
                 assessment.addAutograderAnnotation(
@@ -73,7 +74,10 @@ public final class AutograderRunner {
                         "src/" + position.path().toString(),
                         position.startLine() - 1,
                         position.endLine() - 1,
-                        autograder.translateMessage(problem.getExplanation()));
+                        autograder.translateMessage(problem.getExplanation()),
+                        problem.getCheckName(),
+                        problem.getType(),
+                        problem.getMaximumProblemsForCheck().orElse(null));
             }
 
             return new AutograderStats(problems.size());

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/metajson/AnnotationDTO.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/metajson/AnnotationDTO.java
@@ -1,6 +1,8 @@
 /* Licensed under EPL-2.0 2024. */
 package edu.kit.kastel.sdq.artemis4j.grading.metajson;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.kit.kastel.sdq.artemis4j.client.AnnotationSource;
 
@@ -16,4 +18,6 @@ public record AnnotationDTO(
         @JsonProperty String classFilePath,
         @JsonProperty String customMessageForJSON,
         @JsonProperty Double customPenaltyForJSON,
-        @JsonProperty AnnotationSource source) {}
+        @JsonProperty AnnotationSource source,
+        @JsonProperty List<String> classifiers,
+        @JsonProperty Integer annotationLimit) {}

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/metajson/MetaFeedbackMapper.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/metajson/MetaFeedbackMapper.java
@@ -17,7 +17,7 @@ import edu.kit.kastel.sdq.artemis4j.grading.penalty.MistakeType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MetaFeedbackMapper {
+public final class MetaFeedbackMapper {
     private static final Logger log = LoggerFactory.getLogger(MetaFeedbackMapper.class);
     private static final String METAJSON_TEXT = "CLIENT_DATA";
 

--- a/src/test/java/edu/kit/kastel/sdq/artemis4j/End2EndTest.java
+++ b/src/test/java/edu/kit/kastel/sdq/artemis4j/End2EndTest.java
@@ -4,11 +4,16 @@ package edu.kit.kastel.sdq.artemis4j;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import edu.kit.kastel.sdq.artemis4j.client.AnnotationSource;
 import edu.kit.kastel.sdq.artemis4j.client.ArtemisInstance;
+import edu.kit.kastel.sdq.artemis4j.client.FeedbackDTO;
+import edu.kit.kastel.sdq.artemis4j.client.FeedbackType;
+import edu.kit.kastel.sdq.artemis4j.client.ResultDTO;
+import edu.kit.kastel.sdq.artemis4j.grading.Annotation;
 import edu.kit.kastel.sdq.artemis4j.grading.ArtemisConnection;
 import edu.kit.kastel.sdq.artemis4j.grading.Assessment;
 import edu.kit.kastel.sdq.artemis4j.grading.Course;
@@ -180,5 +185,171 @@ class End2EndTest {
             Assertions.assertTrue(Files.exists(targetPath));
         }
         Assertions.assertFalse(Files.exists(targetPath));
+    }
+
+    @Test
+    void testMergingNotObservableInAssessments() throws ArtemisClientException {
+        // This test checks that the annotation merging is not observable.
+        // The annotations are created separately, then merged before submission and when the assessment is reloaded,
+        // the annotations will still be there (one should not be able to see the merged annotations).
+        MistakeType mistakeType = this.gradingConfig.getMistakeTypeById("custom");
+
+        String defaultFeedbackText = "This is annotation %d";
+        for (int i = 0; i < 10; i++) {
+            // NOTE: the file has 16 lines, so the annotations are created in a way that they don't overlap
+            this.assessment.addAutograderAnnotation(
+                    mistakeType,
+                    "src/edu/kit/informatik/BubbleSort.java",
+                    i + 1,
+                    i + 2,
+                    defaultFeedbackText.formatted(i),
+                    "FirstCheck",
+                    "FIRST_PROBLEM_TYPE",
+                    3);
+        }
+
+        // create a copy of all annotations before submitting (which will merge them)
+        List<Annotation> currentAnnotations = new ArrayList<>(this.assessment.getAnnotations());
+        this.assessment.submit();
+
+        // Check Assessments
+        this.assessment = this.programmingSubmission.tryLock(this.gradingConfig).orElseThrow();
+
+        for (Annotation annotation : this.assessment.getAnnotations()) {
+            Assertions.assertTrue(
+                    currentAnnotations.contains(annotation),
+                    "Annotation \"%s\" is missing after submission".formatted(annotation));
+            currentAnnotations.remove(annotation);
+        }
+
+        Assertions.assertTrue(
+                currentAnnotations.isEmpty(),
+                "There are annotations that were lost after submission: %s".formatted(currentAnnotations));
+    }
+
+    @Test
+    void testAnnotationMerging() throws ArtemisClientException {
+        // This test checks that the annotations are merged and displayed correctly for the student.
+        MistakeType mistakeType = this.gradingConfig.getMistakeTypeById("custom");
+        MistakeType nonCustomMistakeType = this.gradingConfig.getMistakeTypes().get(1);
+
+        String defaultFeedbackText = "This is annotation %d";
+        for (int i = 0; i < 10; i++) {
+            // NOTE: the file has 16 lines, so the annotations are created in a way that they don't overlap
+            this.assessment.addAutograderAnnotation(
+                    mistakeType,
+                    "src/edu/kit/informatik/BubbleSort.java",
+                    i + 1,
+                    i + 2,
+                    defaultFeedbackText.formatted(i),
+                    "FirstCheck",
+                    "FIRST_PROBLEM_TYPE",
+                    3);
+        }
+
+        String otherFeedbackText = "Other Feedback %d";
+        for (int i = 0; i < 5; i++) {
+            this.assessment.addAutograderAnnotation(
+                    mistakeType,
+                    "src/edu/kit/informatik/MergeSort.java",
+                    i + 1,
+                    i + 2,
+                    otherFeedbackText.formatted(i),
+                    "FirstCheck",
+                    "SECOND_PROBLEM_TYPE",
+                    3);
+        }
+
+        for (int i = 0; i < 5; i++) {
+            this.assessment.addAutograderAnnotation(
+                    mistakeType,
+                    "src/edu/kit/informatik/Client.java",
+                    i + 1,
+                    i + 2,
+                    otherFeedbackText.formatted(i),
+                    "FirstCheck",
+                    "SECOND_PROBLEM_TYPE",
+                    3);
+        }
+
+        // add four annotations without custom messages:
+        for (int i = 5; i < 9; i++) {
+            this.assessment.addAutograderAnnotation(
+                    nonCustomMistakeType,
+                    "src/edu/kit/informatik/Client.java",
+                    i + 1,
+                    i + 2,
+                    null,
+                    "SecondCheck",
+                    "THIRD_PROBLEM_TYPE",
+                    3);
+        }
+
+        // add four annotations where only the last has a custom message:
+        for (int i = 9; i < 12; i++) {
+            this.assessment.addAutograderAnnotation(
+                    nonCustomMistakeType,
+                    "src/edu/kit/informatik/Client.java",
+                    i + 1,
+                    i + 2,
+                    null,
+                    "ThirdCheck",
+                    "THIRD_PROBLEM_TYPE",
+                    3);
+        }
+
+        this.assessment.addAutograderAnnotation(
+                nonCustomMistakeType,
+                "src/edu/kit/informatik/Client.java",
+                13,
+                14,
+                "Has used last annotation for message",
+                "ThirdCheck",
+                "THIRD_PROBLEM_TYPE",
+                3);
+
+        // submit the assessment (will merge the annotations)
+        this.assessment.submit();
+
+        // the assessment will not show the merged annotations (it will unmerge them after loading)
+        this.assessment = this.programmingSubmission.tryLock(this.gradingConfig).orElseThrow();
+
+        // so we need to check the submission itself:
+
+        ResultDTO resultDTO = this.programmingSubmission.getRelevantResult().orElseThrow();
+        var feedbacks = ResultDTO.fetchDetailedFeedbacks(
+                this.connection.getClient(),
+                resultDTO.id(),
+                this.programmingSubmission.getParticipationId(),
+                resultDTO.feedbacks());
+
+        List<String> feedbackTexts = new ArrayList<>();
+        for (FeedbackDTO feedbackDTO : feedbacks) {
+            if (feedbackDTO.type() != FeedbackType.MANUAL) {
+                continue;
+            }
+
+            feedbackTexts.add(feedbackDTO.detailText());
+        }
+
+        Assertions.assertEquals(
+                List.of(
+                        // other feedback is 5 annotations in MergeSort and 5 in Client that should be merged
+                        "[Funktionalität:Custom Penalty] Other Feedback 0 (0P)",
+                        "[Funktionalität:Custom Penalty] Other Feedback 1 (0P)",
+                        "[Funktionalität:Custom Penalty] Other Feedback 2. Other problems in MergeSort:(L4, L5), Client:(L1, L2, L3, L4, L5). (0P)",
+                        // all feedbacks in the same file
+                        "[Funktionalität:Custom Penalty] This is annotation 0 (0P)",
+                        "[Funktionalität:Custom Penalty] This is annotation 1 (0P)",
+                        "[Funktionalität:Custom Penalty] This is annotation 2. Other problems in L4, L5, L6, L7, L8, L9, L10. (0P)",
+                        // feedbacks without messages:
+                        "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden",
+                        "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden",
+                        "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden\nExplanation: Other problems in L9.",
+                        // feedbacks where only the last has a message:
+                        "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden",
+                        "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden",
+                        "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden\nExplanation: Has used last annotation for message. Other problems in L12."),
+                feedbackTexts);
     }
 }

--- a/src/test/java/edu/kit/kastel/sdq/artemis4j/End2EndTest.java
+++ b/src/test/java/edu/kit/kastel/sdq/artemis4j/End2EndTest.java
@@ -337,19 +337,19 @@ class End2EndTest {
                         // other feedback is 5 annotations in MergeSort and 5 in Client that should be merged
                         "[Funktionalität:Custom Penalty] Other Feedback 0 (0P)",
                         "[Funktionalität:Custom Penalty] Other Feedback 1 (0P)",
-                        "[Funktionalität:Custom Penalty] Other Feedback 2. Other problems in MergeSort:(L4, L5), Client:(L1, L2, L3, L4, L5). (0P)",
+                        "[Funktionalität:Custom Penalty] Other Feedback 2. Weitere Probleme in MergeSort:(L4, L5), Client:(L1, L2, L3, L4, L5). (0P)",
                         // all feedbacks in the same file
                         "[Funktionalität:Custom Penalty] This is annotation 0 (0P)",
                         "[Funktionalität:Custom Penalty] This is annotation 1 (0P)",
-                        "[Funktionalität:Custom Penalty] This is annotation 2. Other problems in L4, L5, L6, L7, L8, L9, L10. (0P)",
+                        "[Funktionalität:Custom Penalty] This is annotation 2. Weitere Probleme in L4, L5, L6, L7, L8, L9, L10. (0P)",
                         // feedbacks without messages:
                         "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden",
                         "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden",
-                        "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden\nExplanation: Other problems in L9.",
+                        "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden\nExplanation: Weitere Probleme in L9.",
                         // feedbacks where only the last has a message:
                         "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden",
                         "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden",
-                        "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden\nExplanation: Has used last annotation for message. Other problems in L12."),
+                        "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden\nExplanation: Has used last annotation for message. Weitere Probleme in L12."),
                 feedbackTexts);
     }
 }


### PR DESCRIPTION
This PR has some open issues:
- [x] Upper annotation limit is configured to 12, should this be higher? Should this be configurable by artemis4j users?
- [x] Should `ProgrammingSubmission#getLatestResult()` be replaced by `ProgrammingSubmission#getRelevantResult()`?
- [x] Where are you supposed to store translations? At the moment, I store them in a constant in `AnnotationMerger` (where it is used)
- [x] What should be the default for a `FormatString`, english or german?

The implementation has been written, so that one can merge non-autograder annotations as well (if they specify one or more classifiers) and the threshold at which they should be merged.

It might be difficult to understand, why there are multiple classifiers, so I will try to explain this here. The autograder has checks and problem types, one check can emit many problem types and the same problem types can be emitted by different checks. For example, we could have a check `A` that emits annotations with the problem type `P` and there might be another check `B` that emits different annotations with the problem type `P` as well.

The problem types do not define the annotation message, they are used for mapping them to the grading config and globally disabling for example all annotations that are related to visibility.

It would not make sense to group the annotations based on the problem type, because they are not related (will have different messages). That is why the annotations were first grouped by the check that emits them, then (because each check can have different problem types) they are grouped by the problem type.

I wrote the merging code independent of the autograder, so I added a new field called classifiers to an annotation. This list of strings is used to group the annotations (first all annotations with the first classifier are grouped, then in those groups, all with the second classifier are grouped and so on).

#### Concerning the upper annotation limit: 
The autograder checks define different limits for how many annotations should be emitted. For example, the `FieldShouldBeFinal` check is limited to 4 and the `ConcreteCollectionCheck` is limited to 5 annotations.
There are some less frequently occurring checks that do not define a limit, for these the **upper annotation limit** will apply. The code will either use the **upper annotation limit** or the defined limit by the annotation (whatever is smaller), so the limit should be appropriately high. I think 8 - 12 would be a good number? (I am leaning towards the upper limit).
