### PR TITLE
Fix crash when `ProgrammingSubmissionDTO#results` is `null`

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/client/ProgrammingSubmissionDTO.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/client/ProgrammingSubmissionDTO.java
@@ -74,6 +74,10 @@ public record ProgrammingSubmissionDTO(
     }
 
     public List<ResultDTO> nonAutomaticResults() {
+        if (this.results == null) {
+            return List.of();
+        }
+
         return this.results().stream()
                 .filter(r -> r != null && r.assessmentType() != AssessmentType.AUTOMATIC)
                 .toList();

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/ProgrammingSubmission.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/ProgrammingSubmission.java
@@ -87,7 +87,7 @@ public class ProgrammingSubmission extends ArtemisConnectionHolder {
     }
 
     public Optional<ResultDTO> getLatestResult() {
-        if (!this.dto.results().isEmpty()) {
+        if (this.dto.results() != null && !this.dto.results().isEmpty()) {
             return Optional.of(this.dto.results().get(this.dto.results().size() - 1));
         } else {
             return Optional.empty();


### PR DESCRIPTION
Fixes a minor oversight.