### PR TITLE
Don't show points for non-scoring mistake types

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Assessment.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Assessment.java
@@ -513,7 +513,7 @@ public class Assessment extends ArtemisConnectionHolder {
             if (mistakePoints.isPresent()) {
 
                 // Header per mistake type
-                if (ratingGroup.isScoringGroup()) {
+                if (ratingGroup.isScoringGroup() && mistakeType.shouldScore()) {
                     lines.add(GLOBAL_FEEDBACK_MISTAKE_TYPE_HEADER.format(
                             mistakeType.getButtonText(), mistakePoints.get().score()));
                 } else {


### PR DESCRIPTION
If wrong loop type is reported, but should not score, we previously had this global feedback:
```
Methodik [-1P (Range: -4P -- 0P)]
    * Falscher Schleifentyp [-0.5P]:
        * src/edu/kit/kastel/StringUtility.java at line 14
    * unnötige Komplexität (klein) [-0.5P]:
        * src/edu/kit/kastel/StringUtility.java at line 14
        * src/edu/kit/kastel/StringUtility.java at line 14
        * src/edu/kit/kastel/StringUtility.java at line 14
        * src/edu/kit/kastel/StringUtility.java at line 14
        * src/edu/kit/kastel/StringUtility.java at line 14
    * Schwieriger Code [-0.5P]:
        * src/edu/kit/kastel/StringUtility.java at line 13
```
where there is a `[-0.5P]` behind the non-scoring mistake type.

With this PR, we get this:
```
Methodik [-1P (Range: -4P -- 0P)]
    * Falscher Schleifentyp:
        * src/edu/kit/kastel/StringUtility.java at line 14
    * unnötige Komplexität (klein) [-0.5P]:
        * src/edu/kit/kastel/StringUtility.java at line 14
        * src/edu/kit/kastel/StringUtility.java at line 14
        * src/edu/kit/kastel/StringUtility.java at line 14
        * src/edu/kit/kastel/StringUtility.java at line 14
        * src/edu/kit/kastel/StringUtility.java at line 14
    * Schwieriger Code [-0.5P]:
        * src/edu/kit/kastel/StringUtility.java at line 13
```
which makes it obvious which mistake types contributed to the rating group's penalty.