### PR TITLE
Implement some things for intelligrade

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/GradingConfig.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/GradingConfig.java
@@ -31,7 +31,7 @@ public final class GradingConfig {
 
     public static GradingConfig fromDTO(GradingConfigDTO configDTO, ProgrammingExercise exercise)
             throws InvalidGradingConfigException {
-        if (configDTO.isAllowedForExercise(exercise.getId())) {
+        if (!configDTO.isAllowedForExercise(exercise.getId())) {
             throw new InvalidGradingConfigException(
                     "Grading config is not valid for exercise with id " + exercise.getId());
         }

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/MistakeType.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/MistakeType.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.artemis4j.grading.penalty;
 
 import java.util.Collections;

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/MistakeType.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/MistakeType.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import edu.kit.kastel.sdq.artemis4j.i18n.FormatString;
 import edu.kit.kastel.sdq.artemis4j.i18n.TranslatableString;
 
@@ -17,6 +19,7 @@ public final class MistakeType {
     private final FormatString buttonTexts;
     private final MistakeReportingState reporting;
     private final List<String> autograderProblemTypes;
+    private final Highlight highlight;
 
     static void createAndAddToGroup(MistakeTypeDTO dto, boolean shouldScore, RatingGroup ratingGroup) {
         var mistakeType = new MistakeType(dto, shouldScore, ratingGroup);
@@ -41,6 +44,8 @@ public final class MistakeType {
         } else {
             this.reporting = MistakeReportingState.REPORT;
         }
+
+        this.highlight = dto.highlight() == null ? Highlight.DEFAULT : dto.highlight();
     }
 
     public String getId() {
@@ -79,6 +84,15 @@ public final class MistakeType {
         return Collections.unmodifiableList(autograderProblemTypes);
     }
 
+    /**
+     * Returns how the mistake type should be highlighted.
+     *
+     * @return the highlight for the mistake
+     */
+    public Highlight getHighlight() {
+        return this.highlight;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -101,7 +115,19 @@ public final class MistakeType {
                 + message.getDefaultTranslationPattern() + ", buttonTexts="
                 + buttonTexts.getDefaultTranslationPattern() + ", reporting="
                 + reporting + ", autograderProblemTypes="
-                + autograderProblemTypes + '}';
+                + autograderProblemTypes + ", highlight="
+                + highlight + '}';
+    }
+
+    public enum Highlight {
+        NONE,
+        DEFAULT;
+
+        @JsonValue
+        @Override
+        public String toString() {
+            return this.name().toLowerCase();
+        }
     }
 
     record MistakeTypeDTO(
@@ -114,5 +140,6 @@ public final class MistakeType {
             String enabledPenaltyForExercises,
             Map<String, String> additionalButtonTexts,
             Map<String, String> additionalMessages,
-            List<String> autograderProblemTypes) {}
+            List<String> autograderProblemTypes,
+            @JsonProperty(defaultValue = "Highlight.DEFAULT") Highlight highlight) {}
 }

--- a/src/test/java/edu/kit/kastel/sdq/artemis4j/End2EndTest.java
+++ b/src/test/java/edu/kit/kastel/sdq/artemis4j/End2EndTest.java
@@ -1,5 +1,7 @@
-/* Licensed under EPL-2.0 2023-2024. */
+/* Licensed under EPL-2.0 2023-2025. */
 package edu.kit.kastel.sdq.artemis4j;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -23,8 +25,6 @@ import edu.kit.kastel.sdq.artemis4j.grading.TestResult;
 import edu.kit.kastel.sdq.artemis4j.grading.penalty.GradingConfig;
 import edu.kit.kastel.sdq.artemis4j.grading.penalty.MistakeType;
 import org.junit.jupiter.api.*;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class End2EndTest {
@@ -363,8 +363,14 @@ class End2EndTest {
 
     @Test
     void testHighlight() {
-        assertEquals(MistakeType.Highlight.DEFAULT, this.gradingConfig.getMistakeTypeById("custom").getHighlight());
-        assertEquals(MistakeType.Highlight.DEFAULT, this.gradingConfig.getMistakeTypeById("jdEmpty").getHighlight());
-        assertEquals(MistakeType.Highlight.NONE, this.gradingConfig.getMistakeTypeById("magicLiteral").getHighlight());
+        assertEquals(
+                MistakeType.Highlight.DEFAULT,
+                this.gradingConfig.getMistakeTypeById("custom").getHighlight());
+        assertEquals(
+                MistakeType.Highlight.DEFAULT,
+                this.gradingConfig.getMistakeTypeById("jdEmpty").getHighlight());
+        assertEquals(
+                MistakeType.Highlight.NONE,
+                this.gradingConfig.getMistakeTypeById("magicLiteral").getHighlight());
     }
 }

--- a/src/test/java/edu/kit/kastel/sdq/artemis4j/End2EndTest.java
+++ b/src/test/java/edu/kit/kastel/sdq/artemis4j/End2EndTest.java
@@ -24,6 +24,8 @@ import edu.kit.kastel.sdq.artemis4j.grading.penalty.GradingConfig;
 import edu.kit.kastel.sdq.artemis4j.grading.penalty.MistakeType;
 import org.junit.jupiter.api.*;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class End2EndTest {
 
@@ -108,10 +110,10 @@ class End2EndTest {
         this.assessment = this.programmingSubmission.tryLock(this.gradingConfig).orElseThrow();
 
         List<TestResult> tests = this.assessment.getTestResults();
-        Assertions.assertEquals(13, tests.size());
+        assertEquals(13, tests.size());
 
-        Assertions.assertEquals(1, this.assessment.getAnnotations().size());
-        Assertions.assertEquals(
+        assertEquals(1, this.assessment.getAnnotations().size());
+        assertEquals(
                 AnnotationSource.MANUAL_FIRST_ROUND,
                 this.assessment.getAnnotations().get(0).getSource());
     }
@@ -128,13 +130,13 @@ class End2EndTest {
         this.assessment = this.programmingSubmission.tryLock(this.gradingConfig).orElseThrow();
 
         List<TestResult> tests = this.assessment.getTestResults();
-        Assertions.assertEquals(13, tests.size());
+        assertEquals(13, tests.size());
 
-        Assertions.assertEquals(1, this.assessment.getAnnotations().size());
+        assertEquals(1, this.assessment.getAnnotations().size());
         var annotation = this.assessment.getAnnotations().get(0);
-        Assertions.assertEquals(AnnotationSource.MANUAL_FIRST_ROUND, annotation.getSource());
-        Assertions.assertEquals(Optional.of(-2.0), annotation.getCustomScore());
-        Assertions.assertEquals(Optional.of(FEEDBACK_TEXT), annotation.getCustomMessage());
+        assertEquals(AnnotationSource.MANUAL_FIRST_ROUND, annotation.getSource());
+        assertEquals(Optional.of(-2.0), annotation.getCustomScore());
+        assertEquals(Optional.of(FEEDBACK_TEXT), annotation.getCustomMessage());
     }
 
     @Test
@@ -142,16 +144,16 @@ class End2EndTest {
         MistakeType mistakeType = this.gradingConfig.getMistakeTypes().get(1);
 
         this.assessment.addPredefinedAnnotation(mistakeType, "src/edu/kit/informatik/BubbleSort.java", 1, 2, null);
-        Assertions.assertEquals(1, this.assessment.getAnnotations().size());
+        assertEquals(1, this.assessment.getAnnotations().size());
         var oldAnnotations = this.assessment.getAnnotations();
 
         String exportedAssessment = this.assessment.exportAssessment();
 
         this.assessment.clearAnnotations();
-        Assertions.assertEquals(0, this.assessment.getAnnotations().size());
+        assertEquals(0, this.assessment.getAnnotations().size());
 
         this.assessment.importAssessment(exportedAssessment);
-        Assertions.assertEquals(oldAnnotations, this.assessment.getAnnotations());
+        assertEquals(oldAnnotations, this.assessment.getAnnotations());
     }
 
     @Test
@@ -176,11 +178,11 @@ class End2EndTest {
             }
         }
 
-        Assertions.assertEquals(this.programmingSubmission, updatedSubmission);
+        assertEquals(this.programmingSubmission, updatedSubmission);
 
         Assessment newAssessment =
                 updatedSubmission.openAssessment(this.gradingConfig).orElseThrow();
-        Assertions.assertEquals(1, newAssessment.getAnnotations().size());
+        assertEquals(1, newAssessment.getAnnotations().size());
     }
 
     @Test
@@ -338,7 +340,7 @@ class End2EndTest {
             feedbackTexts.add(feedbackDTO.detailText());
         }
 
-        Assertions.assertEquals(
+        assertEquals(
                 List.of(
                         // other feedback is 5 annotations in MergeSort and 5 in Client that should be merged
                         "[Funktionalität:Custom Penalty] Other Feedback 0 (0P)",
@@ -357,5 +359,12 @@ class End2EndTest {
                         "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden",
                         "[Funktionalität:JavaDoc Leer] JavaDoc ist leer oder nicht vorhanden\nExplanation: Has used last annotation for message. Weitere Probleme in L12."),
                 feedbackTexts);
+    }
+
+    @Test
+    void testHighlight() {
+        assertEquals(MistakeType.Highlight.DEFAULT, this.gradingConfig.getMistakeTypeById("custom").getHighlight());
+        assertEquals(MistakeType.Highlight.DEFAULT, this.gradingConfig.getMistakeTypeById("jdEmpty").getHighlight());
+        assertEquals(MistakeType.Highlight.NONE, this.gradingConfig.getMistakeTypeById("magicLiteral").getHighlight());
     }
 }

--- a/src/test/resources/config.json
+++ b/src/test/resources/config.json
@@ -37,7 +37,8 @@
         "threshold": 1,
         "penalty": 5
       },
-      "appliesTo": "functionality"
+      "appliesTo": "functionality",
+      "highlight": "default"
     },
     {
       "shortName": "jdTrivial",
@@ -49,6 +50,21 @@
         "penalty": 5
       },
       "appliesTo": "functionality"
+    },
+    {
+      "shortName": "magicLiteral",
+      "message": "Literal wird nicht als Konstante ausgelagert",
+      "button": "Magic Literal",
+      "penaltyRule": {
+        "shortName": "thresholdPenalty",
+        "threshold": 1,
+        "penalty": 1.0
+      },
+      "appliesTo": "functionality",
+      "autograderProblemTypes": [
+        "MAGIC_LITERAL"
+      ],
+      "highlight": "none"
     }
   ]
 }


### PR DESCRIPTION
This PR ...
- closes #164 
- closes #160 

The highlighter code has been written to allow extensions in the future, like underlines for some buttons instead of changing background color or defining individual colors for buttons. (these would be simple to implement by adding a new enum variant).

This PR exposes the `GradingConfigDTO`, because there wouldn't be any point in writing a wrapper around it.