### PR TITLE
Fix long feedback endpoint name

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/client/FeedbackDTO.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/client/FeedbackDTO.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.artemis4j.client;
 
 import java.util.List;
@@ -58,10 +58,9 @@ public record FeedbackDTO(
                 FeedbackType.MANUAL_UNREFERENCED, null, credits, null, "NEVER", text, null, detailText, null, null);
     }
 
-    public static String fetchLongFeedback(ArtemisClient client, long resultId, long feedbackId)
-            throws ArtemisNetworkException {
+    public static String fetchLongFeedback(ArtemisClient client, long feedbackId) throws ArtemisNetworkException {
         return ArtemisRequest.get()
-                .path(List.of("results", resultId, "feedbacks", feedbackId, "long-feedback"))
+                .path(List.of("feedbacks", feedbackId, "long-feedback"))
                 .executeAndDecode(client, String.class);
     }
 

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/client/ResultDTO.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/client/ResultDTO.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.artemis4j.client;
 
 import java.time.ZonedDateTime;
@@ -91,7 +91,7 @@ public record ResultDTO(
 
             String detailText = feedback.detailText();
             if (feedback.hasLongFeedbackText()) {
-                detailText = FeedbackDTO.fetchLongFeedback(client, resultId, feedback.id());
+                detailText = FeedbackDTO.fetchLongFeedback(client, feedback.id());
             }
             cleanedFeedbacks.add(new FeedbackDTO(detailText, feedback));
         }


### PR DESCRIPTION
This Artemis PR https://github.com/ls1intum/Artemis/pull/10292 changed the long feedback endpoint name from `results/{resultId}/feedbacks/{feedbackId}/long-feedback` to only `feedbacks/{feedbackId}/long-feedback`.