### PR TITLE
Implement subgroups #161

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>edu.kit.kastel.sdq</groupId>
   <artifactId>artemis4j</artifactId>
-  <version>7.10.2-SNAPSHOT</version>
+  <version>8.0.0-SNAPSHOT</version>
 
   <name>Artemis4J</name>
   <description>Artemis4J is a Java library for interacting with the Artemis teaching system.</description>

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/GradingConfig.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/GradingConfig.java
@@ -3,8 +3,6 @@ package edu.kit.kastel.sdq.artemis4j.grading.penalty;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -36,19 +34,20 @@ public final class GradingConfig {
                     "Grading config is not valid for exercise with id " + exercise.getId());
         }
 
-        var ratingGroups =
-                configDTO.ratingGroups().stream().map(RatingGroup::new).toList();
-        var ratingGroupsById = ratingGroups.stream().collect(Collectors.toMap(RatingGroup::getId, Function.identity()));
-
+        List<RatingGroup> ratingGroups = RatingGroup.createRatingGroups(configDTO.ratingGroups());
         for (MistakeType.MistakeTypeDTO dto : configDTO.mistakeTypes()) {
             if (!StringUtil.matchMaybe(exercise.getShortName(), dto.enabledForExercises())) {
                 continue;
             }
 
+            var group = ratingGroups.stream()
+                    .flatMap(ratingGroup -> ratingGroup.findGroup(dto.appliesTo()).stream())
+                    .findFirst()
+                    .orElseThrow(() -> new InvalidGradingConfigException("No group found for mistake type %s with id %s"
+                            .formatted(dto.shortName(), dto.appliesTo())));
+
             MistakeType.createAndAddToGroup(
-                    dto,
-                    StringUtil.matchMaybe(exercise.getShortName(), dto.enabledPenaltyForExercises()),
-                    ratingGroupsById.get(dto.appliesTo()));
+                    dto, StringUtil.matchMaybe(exercise.getShortName(), dto.enabledPenaltyForExercises()), group);
         }
 
         var config = new GradingConfig(
@@ -108,7 +107,7 @@ public final class GradingConfig {
     }
 
     private Stream<MistakeType> streamMistakeTypes() {
-        return ratingGroups.stream().map(RatingGroup::getMistakeTypes).flatMap(List::stream);
+        return ratingGroups.stream().map(RatingGroup::getAllMistakeTypes).flatMap(List::stream);
     }
 
     public record GradingConfigDTO(

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/MistakeType.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/MistakeType.java
@@ -60,6 +60,27 @@ public final class MistakeType {
         return ratingGroup;
     }
 
+    public boolean isAssociatedWith(RatingGroup group) {
+        return this.ratingGroup.isAssociatedWith(group);
+    }
+
+    /**
+     * Returns the display name of the representative group for this mistake types group.
+     * For a group that is not a subgroup, this will return the {@link RatingGroup#getDisplayName()} of the group.
+     * For a subgroup, this will return the {@link RatingGroup#getDisplayName()} of the main <b>parent</b> group.
+     *
+     * @return the display name of the representative group
+     */
+    public TranslatableString getRepresentativeGroupDisplayName() {
+        RatingGroup group = this.ratingGroup;
+
+        while (group.getParent() != null) {
+            group = group.getParent();
+        }
+
+        return group.getDisplayName();
+    }
+
     public TranslatableString getMessage() {
         return message.format();
     }

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/RatingGroup.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/RatingGroup.java
@@ -1,29 +1,100 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.artemis4j.grading.penalty;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
 
 import edu.kit.kastel.sdq.artemis4j.i18n.FormatString;
 import edu.kit.kastel.sdq.artemis4j.i18n.TranslatableString;
 
 public final class RatingGroup {
+    // Subgroups are indicated by a double colon "::" in the id.
+    // For example "modelling::oop" would indicate a subgroup "oop" in the rating group "modelling".
+    private static final String SUBGROUP_SEPARATOR = "::";
+
     private final String id;
     private final FormatString displayName;
     private final double minPenalty;
     private final double maxPenalty;
     private final List<MistakeType> mistakeTypes;
+    private final Map<String, RatingGroup> subRatingGroups;
+    private final RatingGroup parentRatingGroup;
 
-    RatingGroup(RatingGroupDTO dto) {
-        double negativeLimit = dto.negativeLimit() != null ? dto.negativeLimit() : Double.NEGATIVE_INFINITY;
-        double positiveLimit = dto.positiveLimit() != null ? dto.positiveLimit() : Double.POSITIVE_INFINITY;
+    private static double parseLimit(
+            double limit, Double parentLimit, BiFunction<? super Double, ? super Double, String> errorMessageBuilder) {
+        // This ensures that the limit is always positive. When there is a negative limit,
+        // negate it to make it positive and then later negate it again.
+        //
+        // This works, for example given limit -5 and parentLimit -10:
+        // 1. limit = -5, parentLimit = -10
+        // 2. limit = 5, parentLimit = 10
+        // -> result = 5 -> -5
+        if (limit < 0.0) {
+            return -parseLimit(
+                    -limit,
+                    parentLimit == null ? null : -parentLimit,
+                    (current, parent) -> errorMessageBuilder.apply(-current, -parent));
+        }
 
+        double result = limit;
+        if (parentLimit != null) {
+            // if the limit is positive infinity, there was no limit defined
+            // -> inherit the limit from the parent group
+
+            // The limit of this group should not be larger than the limit of the parent group.
+            // e.g. parent group has a limit of 5 and this group has a limit of 10, which is invalid.
+            if (limit < Double.POSITIVE_INFINITY && parentLimit < result) {
+                throw new IllegalArgumentException(errorMessageBuilder.apply(result, parentLimit));
+            }
+
+            // If the parent group has a positive limit, the smaller limit is prioritized.
+            //
+            // For example, if the parent group has a limit of 10 and this group has a limit of 5,
+            // the limit should be 5.
+            result = Math.min(result, parentLimit);
+        }
+
+        return result;
+    }
+
+    private RatingGroup(RatingGroupDTO dto, RatingGroup parentRatingGroup) {
+        // The negative limit defines the amount of points that can be subtracted at most.
+        double negativeLimit = parseLimit(
+                dto.negativeLimit() == null ? Double.NEGATIVE_INFINITY : dto.negativeLimit(),
+                parentRatingGroup == null ? null : parentRatingGroup.getMinPenalty(),
+                (currentLimit, parentLimit) ->
+                        "The negative limit of the subgroup %s (%fP) is smaller than the limit of its parent group %s (%fP)"
+                                .formatted(
+                                        dto.shortName(),
+                                        currentLimit,
+                                        Objects.requireNonNull(parentRatingGroup)
+                                                .getId(),
+                                        parentLimit));
+
+        // The positive limit defines the amount of points that can be given at most.
+        double positiveLimit = parseLimit(
+                dto.positiveLimit() == null ? Double.POSITIVE_INFINITY : dto.positiveLimit(),
+                parentRatingGroup == null ? null : parentRatingGroup.getMaxPenalty(),
+                (currentLimit, parentLimit) ->
+                        "The positive limit of the subgroup %s (%fP) is larger than the limit of its parent group %s (%fP)"
+                                .formatted(
+                                        dto.shortName(),
+                                        currentLimit,
+                                        Objects.requireNonNull(parentRatingGroup)
+                                                .getId(),
+                                        parentLimit));
+
+        // sanity check that everything was calculated correctly
         if (negativeLimit > positiveLimit) {
-            throw new IllegalArgumentException("Invalid penalty range for rating group: %fP -- %fP"
-                    .formatted(dto.negativeLimit(), dto.positiveLimit()));
+            throw new IllegalArgumentException("Invalid penalty range for rating group: %fP -- %fP (%fP -- %fP)"
+                    .formatted(dto.negativeLimit(), dto.positiveLimit(), negativeLimit, positiveLimit));
         }
 
         this.id = dto.shortName();
@@ -31,10 +102,124 @@ public final class RatingGroup {
         this.minPenalty = negativeLimit;
         this.maxPenalty = positiveLimit;
         this.mistakeTypes = new ArrayList<>();
+
+        // Each rating group is aware of its parent (if it is a subgroup) and its subgroups (if there are any):
+        this.subRatingGroups = new LinkedHashMap<>();
+        this.parentRatingGroup = parentRatingGroup;
     }
 
-    public List<MistakeType> getMistakeTypes() {
-        return Collections.unmodifiableList(this.mistakeTypes);
+    static List<RatingGroup> createRatingGroups(Iterable<RatingGroupDTO> dtos) throws InvalidGradingConfigException {
+        Map<String, RatingGroup> ratingGroupsById = new LinkedHashMap<>();
+        // The subgroups might appear before the parent in the list of groups, that's
+        // why they are collected separately first
+        Collection<RatingGroupDTO> subRatingGroups = new ArrayList<>();
+        for (RatingGroup.RatingGroupDTO ratingGroupDTO : dtos) {
+            String id = ratingGroupDTO.shortName();
+
+            if (id.contains(RatingGroup.SUBGROUP_SEPARATOR)) {
+                subRatingGroups.add(ratingGroupDTO);
+            } else {
+                ratingGroupsById.put(id, new RatingGroup(ratingGroupDTO, null));
+            }
+        }
+
+        for (var ratingGroup : subRatingGroups) {
+            String id = ratingGroup.shortName();
+            String parentId = id.substring(0, id.indexOf(RatingGroup.SUBGROUP_SEPARATOR));
+            RatingGroup parent = ratingGroupsById.get(parentId);
+            if (parent == null) {
+                throw new InvalidGradingConfigException(
+                        "Subgroup '%s' has no parent group with id '%s'".formatted(id, parentId));
+            }
+            parent.addSubGroup(id, ratingGroup);
+        }
+
+        return new ArrayList<>(ratingGroupsById.values());
+    }
+
+    /**
+     * Adds the given rating group to this group assuming that it is a subgroup of this.
+     *
+     * @param id the id of the subgroup, starting with the id of this group, like modelling::oop
+     * @param subGroupDto the DTO of the subgroup
+     * @throws IllegalArgumentException if the id does not start with this group's id
+     * @throws IllegalArgumentException if the id is not for a subgroup (nothing separated by "::")
+     * @throws IllegalArgumentException if the id is for a nested subgroup (e.g. modelling::oop::subgroup)
+     * @throws IllegalArgumentException if the subgroup already exists
+     */
+    private void addSubGroup(String id, RatingGroupDTO subGroupDto) {
+        var path = id.split(SUBGROUP_SEPARATOR, -1);
+        if (path.length < 2) {
+            throw new IllegalArgumentException("Invalid subgroup path: %s".formatted(id));
+        }
+
+        if (!this.id.equals(path[0])) {
+            throw new IllegalArgumentException("Subgroup %s does not belong to group %s".formatted(id, this.id));
+        }
+
+        if (path[1].contains(SUBGROUP_SEPARATOR)) {
+            throw new IllegalArgumentException("Subgroup %s is a nested subgroup".formatted(id));
+        }
+
+        if (this.subRatingGroups.containsKey(path[1])) {
+            throw new IllegalArgumentException("Subgroup %s already exists".formatted(id));
+        }
+
+        this.subRatingGroups.put(path[1], new RatingGroup(subGroupDto, this));
+    }
+
+    /**
+     * Finds the rating group with the given id in this group and its subgroups.
+     *
+     * @param id the id of the group to find
+     * @return an optional with the group if it was found, empty otherwise
+     */
+    Optional<RatingGroup> findGroup(String id) {
+        if (this.id.equals(id)) {
+            return Optional.of(this);
+        }
+
+        for (var entry : this.listSubGroups()) {
+            var group = entry.findGroup(id);
+            if (group.isPresent()) {
+                return group;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the parent of this rating group, if any.
+     *
+     * @return the parent group or null if this is a top-level group
+     */
+    public RatingGroup getParent() {
+        return this.parentRatingGroup;
+    }
+
+    /**
+     * Returns the list of all subgroups of this group, if any.
+     *
+     * @return the subgroups or an empty list if there are none
+     */
+    public List<RatingGroup> listSubGroups() {
+        return List.copyOf(this.subRatingGroups.values());
+    }
+
+    /**
+     * Returns the list of all mistake types in this group and its subgroups.
+     *
+     * @return a list with all mistake types
+     */
+    public List<MistakeType> getAllMistakeTypes() {
+        List<MistakeType> result = new ArrayList<>(this.mistakeTypes);
+
+        for (var group : this.subRatingGroups.values()) {
+            result.addAll(group.getAllMistakeTypes());
+        }
+
+        return Collections.unmodifiableList(result);
     }
 
     public String getId() {
@@ -54,7 +239,31 @@ public final class RatingGroup {
     }
 
     public boolean isScoringGroup() {
-        return minPenalty != 0 || maxPenalty != 0;
+        return this.getMinPenalty() != 0 || this.getMaxPenalty() != 0;
+    }
+
+    private List<RatingGroup> parents() {
+        List<RatingGroup> parents = new ArrayList<>();
+        RatingGroup parent = this.parentRatingGroup;
+        while (parent != null) {
+            parents.add(parent);
+            parent = parent.getParent();
+        }
+        return parents;
+    }
+
+    boolean isAssociatedWith(RatingGroup ratingGroup) {
+        if (this.equals(ratingGroup)) {
+            return true;
+        }
+
+        for (var parent : this.parents()) {
+            if (parent.equals(ratingGroup)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/test/java/edu/kit/kastel/sdq/artemis4j/SubgroupTest.java
+++ b/src/test/java/edu/kit/kastel/sdq/artemis4j/SubgroupTest.java
@@ -261,32 +261,31 @@ class SubgroupTest {
         MistakeType mistakeType = this.gradingConfig.getMistakeTypeById("systemexit");
 
         this.assessment.addPredefinedAnnotation(
-            mistakeType, new Location("src/edu/kit/informatik/BubbleSort.java", 0, 1), null);
+                mistakeType, new Location("src/edu/kit/informatik/BubbleSort.java", 0, 1), null);
         this.assessment.addPredefinedAnnotation(
-            this.gradingConfig.getMistakeTypeById("magicLiteral"),
-            new Location("src/edu/kit/informatik/BubbleSort.java", 1, 2),
-            null);
+                this.gradingConfig.getMistakeTypeById("magicLiteral"),
+                new Location("src/edu/kit/informatik/BubbleSort.java", 1, 2),
+                null);
         this.assessment.addPredefinedAnnotation(
-            this.gradingConfig.getMistakeTypeById("instanceof"),
-            new Location("src/edu/kit/informatik/BubbleSort.java", 3, 4),
-            null);
+                this.gradingConfig.getMistakeTypeById("instanceof"),
+                new Location("src/edu/kit/informatik/BubbleSort.java", 3, 4),
+                null);
         this.assessment.addPredefinedAnnotation(
-            this.gradingConfig.getMistakeTypeById("instanceof"),
-            new Location("src/edu/kit/informatik/BubbleSort.java", 4, 5),
-            null);
+                this.gradingConfig.getMistakeTypeById("instanceof"),
+                new Location("src/edu/kit/informatik/BubbleSort.java", 4, 5),
+                null);
 
         assertEquals(
-            List.of(
-                "Funktionalität [-14P (Range: -20P -- ∞P)]",
-                "    * System.exit [-5P]:",
-                "        * src/edu/kit/informatik/BubbleSort.java at line 1",
-                "    * Magic Literal [-1P]:",
-                "        * src/edu/kit/informatik/BubbleSort.java at line 2",
-                "    * instanceof [-10P]:",
-                "        * src/edu/kit/informatik/BubbleSort.java at lines 4, 5"),
-            this.getGlobalFeedbackLines());
+                List.of(
+                        "Funktionalität [-14P (Range: -20P -- ∞P)]",
+                        "    * System.exit [-5P]:",
+                        "        * src/edu/kit/informatik/BubbleSort.java at line 1",
+                        "    * Magic Literal [-1P]:",
+                        "        * src/edu/kit/informatik/BubbleSort.java at line 2",
+                        "    * instanceof [-10P]:",
+                        "        * src/edu/kit/informatik/BubbleSort.java at lines 4, 5"),
+                this.getGlobalFeedbackLines());
     }
-
 
     @Test
     void testSubgroupsAreGroupedCorrectly() throws ArtemisClientException {

--- a/src/test/java/edu/kit/kastel/sdq/artemis4j/SubgroupTest.java
+++ b/src/test/java/edu/kit/kastel/sdq/artemis4j/SubgroupTest.java
@@ -1,0 +1,368 @@
+/* Licensed under EPL-2.0 2025. */
+package edu.kit.kastel.sdq.artemis4j;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import edu.kit.kastel.sdq.artemis4j.client.ArtemisInstance;
+import edu.kit.kastel.sdq.artemis4j.client.FeedbackDTO;
+import edu.kit.kastel.sdq.artemis4j.client.FeedbackType;
+import edu.kit.kastel.sdq.artemis4j.client.ResultDTO;
+import edu.kit.kastel.sdq.artemis4j.grading.ArtemisConnection;
+import edu.kit.kastel.sdq.artemis4j.grading.Assessment;
+import edu.kit.kastel.sdq.artemis4j.grading.Course;
+import edu.kit.kastel.sdq.artemis4j.grading.ProgrammingExercise;
+import edu.kit.kastel.sdq.artemis4j.grading.ProgrammingSubmission;
+import edu.kit.kastel.sdq.artemis4j.grading.location.Location;
+import edu.kit.kastel.sdq.artemis4j.grading.penalty.GradingConfig;
+import edu.kit.kastel.sdq.artemis4j.grading.penalty.InvalidGradingConfigException;
+import edu.kit.kastel.sdq.artemis4j.grading.penalty.MistakeType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * This tests the subgroup feature which can be used to define subgroups of rating groups.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SubgroupTest {
+
+    // Configure a simple Programming exercise (Sorting algorithms in Artemis
+    // (Default Template: Package Name: edu.kit.informatik))
+    private static final String INSTRUCTOR_USER = System.getenv("INSTRUCTOR_USER");
+    private static final String INSTRUCTOR_PASSWORD = System.getenv("INSTRUCTOR_PASSWORD");
+    private static final String STUDENT_USER = System.getenv("STUDENT_USER");
+    private static final String ARTEMIS_URL = System.getenv("ARTEMIS_URL");
+    private static final String COURSE_ID = System.getenv("COURSE_ID");
+    private static final String PROGRAMMING_EXERCISE_ID = System.getenv("PROGRAMMING_EXERCISE_ID");
+
+    private ArtemisInstance artemisInstance;
+    private ArtemisConnection connection;
+    private Course course;
+    private ProgrammingExercise exercise;
+    private ProgrammingSubmission programmingSubmission;
+    private Assessment assessment;
+    private GradingConfig gradingConfig;
+
+    @BeforeAll
+    void checkConfiguration() {
+        Assertions.assertNotNull(INSTRUCTOR_USER);
+        Assertions.assertNotNull(INSTRUCTOR_PASSWORD);
+        Assertions.assertNotNull(STUDENT_USER);
+        Assertions.assertNotNull(ARTEMIS_URL);
+        Assertions.assertNotNull(COURSE_ID);
+        Assertions.assertNotNull(PROGRAMMING_EXERCISE_ID);
+    }
+
+    @BeforeEach
+    void setup() throws ArtemisClientException, IOException {
+        this.artemisInstance = new ArtemisInstance(ARTEMIS_URL);
+        this.connection = ArtemisConnection.connectWithUsernamePassword(
+                this.artemisInstance, INSTRUCTOR_USER, INSTRUCTOR_PASSWORD);
+
+        this.course = this.connection.getCourses().stream()
+                .filter(c -> c.getId() == Integer.parseInt(COURSE_ID))
+                .findFirst()
+                .orElseThrow();
+        this.exercise = this.course.getProgrammingExercises().stream()
+                .filter(e -> e.getId() == Long.parseLong(PROGRAMMING_EXERCISE_ID))
+                .findFirst()
+                .orElseThrow();
+
+        var submissions = this.exercise.fetchSubmissions();
+        this.programmingSubmission = submissions.stream()
+                .filter(a -> a.getParticipantIdentifier().equals(STUDENT_USER))
+                .findFirst()
+                .orElseThrow();
+
+        this.gradingConfig = GradingConfig.readFromString(
+                Files.readString(Path.of("src/test/resources/config.json")), this.exercise);
+
+        // ensure that the submission is locked
+        this.assessment = this.programmingSubmission.tryLock(this.gradingConfig).orElseThrow();
+        this.assessment.clearAnnotations();
+
+        Assertions.assertTrue(this.assessment.getAnnotations().isEmpty());
+    }
+
+    /**
+     * Tests that a subgroup without a parent group is not allowed.
+     */
+    @Test
+    void testSubgroupWithoutParent() {
+        var configString =
+                """
+            {
+                "shortName": "E2E",
+                "positiveFeedbackAllowed": true,
+                "ratingGroups": [
+                    {
+                        "shortName": "functionality::quality",
+                        "displayName": "Code Qualität",
+                        "additionalDisplayNames": {
+                            "en": "Code Quality"
+                        },
+                        "negativeLimit": -3,
+                        "positiveLimit": null
+                    }
+                ],
+                "mistakeTypes": [
+                    {
+                        "shortName": "unused",
+                        "button": "Unused Element",
+                        "message": "Das Element wird nicht verwendet",
+                        "penaltyRule": {
+                            "shortName": "thresholdPenalty",
+                            "threshold": 1,
+                            "penalty": 1.0
+                        },
+                        "appliesTo": "functionality::quality"
+                    }
+                ]
+            }
+
+            """;
+
+        assertThrowsExactly(
+                InvalidGradingConfigException.class,
+                () -> GradingConfig.readFromString(configString, this.exercise),
+                "Subgroup 'functionality::quality' has no parent group with id 'functionality'");
+    }
+
+    /**
+     * This test checks that nested subgroups like "functionality::quality::test" are forbidden.
+     * This is a temporary restriction that could be removed in the future.
+     */
+    @Test
+    void testNestedSubgroup() {
+        var configString =
+                """
+            {
+                "shortName": "E2E",
+                "positiveFeedbackAllowed": true,
+                "ratingGroups": [
+                    {
+                        "shortName": "functionality",
+                        "displayName": "Code Qualität",
+                        "additionalDisplayNames": {
+                            "en": "Code Quality"
+                        },
+                        "negativeLimit": -3,
+                        "positiveLimit": null
+                    },
+                    {
+                        "shortName": "functionality::quality",
+                        "displayName": "Code Qualität",
+                        "additionalDisplayNames": {
+                            "en": "Code Quality"
+                        },
+                        "negativeLimit": -3,
+                        "positiveLimit": null
+                    },
+                    {
+                        "shortName": "functionality::quality::extra",
+                        "displayName": "Code Qualität",
+                        "additionalDisplayNames": {
+                            "en": "Code Quality"
+                        },
+                        "negativeLimit": -3,
+                        "positiveLimit": null
+                    }
+                ],
+                "mistakeTypes": [
+                    {
+                        "shortName": "unused",
+                        "button": "Unused Element",
+                        "message": "Das Element wird nicht verwendet",
+                        "penaltyRule": {
+                            "shortName": "thresholdPenalty",
+                            "threshold": 1,
+                            "penalty": 1.0
+                        },
+                        "appliesTo": "functionality::quality"
+                    }
+                ]
+            }
+
+            """;
+
+        assertThrowsExactly(
+                IllegalArgumentException.class,
+                () -> GradingConfig.readFromString(configString, this.exercise),
+                "Subgroup functionality::quality::extra is a nested subgroup");
+    }
+
+    private List<String> getGlobalFeedbackLines() throws ArtemisClientException {
+        this.assessment.submit();
+        // after submitting, we need to check that the global feedback looks as expected
+        this.assessment = this.programmingSubmission.tryLock(this.gradingConfig).orElseThrow();
+
+        ResultDTO resultDTO = this.programmingSubmission.getRelevantResult().orElseThrow();
+        var feedbacks = ResultDTO.fetchDetailedFeedbacks(
+                this.connection.getClient(),
+                resultDTO.id(),
+                this.programmingSubmission.getParticipationId(),
+                resultDTO.feedbacks());
+
+        List<String> globalFeedbackLines = new ArrayList<>();
+        for (FeedbackDTO feedbackDTO : feedbacks) {
+            if (feedbackDTO.type() != FeedbackType.MANUAL_UNREFERENCED || feedbackDTO.visibility() != null) {
+                continue;
+            }
+
+            globalFeedbackLines.addAll(Arrays.asList(feedbackDTO.detailText().split("\\n")));
+        }
+
+        return globalFeedbackLines;
+    }
+
+    /**
+     * Tests that the limit defined in the subgroup is respected.
+     *
+     * @throws ArtemisClientException if there are problems with artemis
+     */
+    @Test
+    void testSubgroupLimitNotExceeded() throws ArtemisClientException {
+        MistakeType mistakeType = this.gradingConfig.getMistakeTypeById("systemexit");
+
+        this.assessment.addPredefinedAnnotation(
+                mistakeType, new Location("src/edu/kit/informatik/BubbleSort.java", 0, 1), null);
+        this.assessment.addPredefinedAnnotation(
+                this.gradingConfig.getMistakeTypeById("magicLiteral"),
+                new Location("src/edu/kit/informatik/BubbleSort.java", 1, 2),
+                null);
+
+        assertEquals(
+                List.of(
+                        "Funktionalität [-4P (Range: -20P -- ∞P)]",
+                        "    * System.exit [-5P]:",
+                        "        * src/edu/kit/informatik/BubbleSort.java at line 1",
+                        "    * Magic Literal [-1P]:",
+                        "        * src/edu/kit/informatik/BubbleSort.java at line 2"),
+                this.getGlobalFeedbackLines());
+    }
+
+    @Test
+    void testSubgroupsAreGroupedCorrectly() throws ArtemisClientException {
+        // This test checks that the annotations are merged and displayed correctly for the student.
+        MistakeType mistakeType = this.gradingConfig.getMistakeTypeById("visibility");
+        MistakeType nonCustomMistakeType = this.gradingConfig.getMistakeTypeById("unused");
+
+        String defaultFeedbackText = "This is annotation %d";
+        for (int i = 0; i < 10; i++) {
+            // NOTE: the file has 16 lines, so the annotations are created in a way that they don't overlap
+            this.assessment.addAutograderAnnotation(
+                    mistakeType,
+                    new Location("src/edu/kit/informatik/BubbleSort.java", i, i),
+                    defaultFeedbackText.formatted(i),
+                    "FirstCheck",
+                    "FIRST_PROBLEM_TYPE",
+                    3);
+        }
+
+        String otherFeedbackText = "Other Feedback %d";
+        for (int i = 0; i < 5; i++) {
+            this.assessment.addAutograderAnnotation(
+                    mistakeType,
+                    new Location("src/edu/kit/informatik/MergeSort.java", i, i),
+                    otherFeedbackText.formatted(i),
+                    "FirstCheck",
+                    "SECOND_PROBLEM_TYPE",
+                    3);
+        }
+
+        // start at line 0 and end at line 5 (L1-6)
+        for (int i = 0; i < 5; i++) {
+            this.assessment.addAutograderAnnotation(
+                    mistakeType,
+                    new Location("src/edu/kit/informatik/Client.java", i, i),
+                    otherFeedbackText.formatted(i),
+                    "FirstCheck",
+                    "SECOND_PROBLEM_TYPE",
+                    3);
+        }
+
+        // add four annotations without custom messages:
+        for (int i = 5; i < 9; i++) {
+            this.assessment.addAutograderAnnotation(
+                    nonCustomMistakeType,
+                    new Location("src/edu/kit/informatik/Client.java", i, i),
+                    null,
+                    "SecondCheck",
+                    "THIRD_PROBLEM_TYPE",
+                    3);
+        }
+
+        // add four annotations where only the last has a custom message:
+        for (int i = 9; i < 12; i++) {
+            this.assessment.addAutograderAnnotation(
+                    nonCustomMistakeType,
+                    new Location("src/edu/kit/informatik/Client.java", i, i),
+                    null,
+                    "ThirdCheck",
+                    "THIRD_PROBLEM_TYPE",
+                    3);
+        }
+
+        this.assessment.addAutograderAnnotation(
+                nonCustomMistakeType,
+                new Location("src/edu/kit/informatik/Client.java", 13, 13),
+                "Has used last annotation for message",
+                "ThirdCheck",
+                "THIRD_PROBLEM_TYPE",
+                3);
+
+        // submit the assessment (will merge the annotations)
+        this.assessment.submit();
+
+        // the assessment will not show the merged annotations (it will unmerge them after loading)
+        this.assessment = this.programmingSubmission.tryLock(this.gradingConfig).orElseThrow();
+
+        // so we need to check the submission itself:
+
+        ResultDTO resultDTO = this.programmingSubmission.getRelevantResult().orElseThrow();
+        var feedbacks = ResultDTO.fetchDetailedFeedbacks(
+                this.connection.getClient(),
+                resultDTO.id(),
+                this.programmingSubmission.getParticipationId(),
+                resultDTO.feedbacks());
+
+        List<String> feedbackTexts = new ArrayList<>();
+        for (FeedbackDTO feedbackDTO : feedbacks) {
+            if (feedbackDTO.type() != FeedbackType.MANUAL) {
+                continue;
+            }
+
+            feedbackTexts.add(feedbackDTO.detailText());
+        }
+
+        assertEquals(
+                List.of(
+                        // other feedback is 5 annotations in MergeSort and 5 in Client that should be merged
+                        "[Funktionalität:Sichtbarkeit] Die Sichtbarkeit ist nicht korrekt\nExplanation: Other Feedback 0",
+                        "[Funktionalität:Sichtbarkeit] Die Sichtbarkeit ist nicht korrekt\nExplanation: Other Feedback 1",
+                        "[Funktionalität:Sichtbarkeit] Die Sichtbarkeit ist nicht korrekt\nExplanation: Other Feedback 2. Weitere Probleme in Client:(L1, L2, L3, L4, L5), MergeSort:(L4, L5).",
+                        // all feedbacks in the same file
+                        "[Funktionalität:Sichtbarkeit] Die Sichtbarkeit ist nicht korrekt\nExplanation: This is annotation 0",
+                        "[Funktionalität:Sichtbarkeit] Die Sichtbarkeit ist nicht korrekt\nExplanation: This is annotation 1",
+                        "[Funktionalität:Sichtbarkeit] Die Sichtbarkeit ist nicht korrekt\nExplanation: This is annotation 2. Weitere Probleme in L4, L5, L6, L7, L8, L9, L10.",
+                        // feedbacks without messages:
+                        "[Funktionalität:Unused Element] Das Element wird nicht verwendet",
+                        "[Funktionalität:Unused Element] Das Element wird nicht verwendet",
+                        "[Funktionalität:Unused Element] Das Element wird nicht verwendet\nExplanation: Weitere Probleme in L9.",
+                        // feedbacks where only the last has a message:
+                        "[Funktionalität:Unused Element] Das Element wird nicht verwendet",
+                        "[Funktionalität:Unused Element] Das Element wird nicht verwendet",
+                        "[Funktionalität:Unused Element] Das Element wird nicht verwendet\nExplanation: Has used last annotation for message. Weitere Probleme in L12."),
+                feedbackTexts);
+    }
+}

--- a/src/test/java/edu/kit/kastel/sdq/artemis4j/SubgroupTest.java
+++ b/src/test/java/edu/kit/kastel/sdq/artemis4j/SubgroupTest.java
@@ -251,6 +251,43 @@ class SubgroupTest {
                 this.getGlobalFeedbackLines());
     }
 
+    /**
+     * Tests that the limit defined in the subgroup is independent of other subgroups.
+     *
+     * @throws ArtemisClientException if there are problems with artemis
+     */
+    @Test
+    void testOtherSubgroupsAreIndependent() throws ArtemisClientException {
+        MistakeType mistakeType = this.gradingConfig.getMistakeTypeById("systemexit");
+
+        this.assessment.addPredefinedAnnotation(
+            mistakeType, new Location("src/edu/kit/informatik/BubbleSort.java", 0, 1), null);
+        this.assessment.addPredefinedAnnotation(
+            this.gradingConfig.getMistakeTypeById("magicLiteral"),
+            new Location("src/edu/kit/informatik/BubbleSort.java", 1, 2),
+            null);
+        this.assessment.addPredefinedAnnotation(
+            this.gradingConfig.getMistakeTypeById("instanceof"),
+            new Location("src/edu/kit/informatik/BubbleSort.java", 3, 4),
+            null);
+        this.assessment.addPredefinedAnnotation(
+            this.gradingConfig.getMistakeTypeById("instanceof"),
+            new Location("src/edu/kit/informatik/BubbleSort.java", 4, 5),
+            null);
+
+        assertEquals(
+            List.of(
+                "Funktionalität [-14P (Range: -20P -- ∞P)]",
+                "    * System.exit [-5P]:",
+                "        * src/edu/kit/informatik/BubbleSort.java at line 1",
+                "    * Magic Literal [-1P]:",
+                "        * src/edu/kit/informatik/BubbleSort.java at line 2",
+                "    * instanceof [-10P]:",
+                "        * src/edu/kit/informatik/BubbleSort.java at lines 4, 5"),
+            this.getGlobalFeedbackLines());
+    }
+
+
     @Test
     void testSubgroupsAreGroupedCorrectly() throws ArtemisClientException {
         // This test checks that the annotations are merged and displayed correctly for the student.

--- a/src/test/resources/config.json
+++ b/src/test/resources/config.json
@@ -10,6 +10,15 @@
       },
       "negativeLimit": -20,
       "positiveLimit": null
+    },
+    {
+      "shortName": "functionality::quality",
+      "displayName": "Code Qualität",
+      "additionalDisplayNames": {
+        "en": "Code Quality"
+      },
+      "negativeLimit": -3,
+      "positiveLimit": null
     }
   ],
   "mistakeTypes": [
@@ -65,6 +74,39 @@
         "MAGIC_LITERAL"
       ],
       "highlight": "none"
+    },
+    {
+      "shortName": "unused",
+      "button": "Unused Element",
+      "message": "Das Element wird nicht verwendet",
+      "penaltyRule": {
+        "shortName": "thresholdPenalty",
+        "threshold": 1,
+        "penalty": 1.0
+      },
+      "appliesTo": "functionality::quality"
+    },
+    {
+      "shortName": "visibility",
+      "button": "Sichtbarkeit",
+      "message": "Die Sichtbarkeit ist nicht korrekt",
+      "penaltyRule": {
+        "shortName": "thresholdPenalty",
+        "threshold": 1,
+        "penalty": 0.5
+      },
+      "appliesTo": "functionality::quality"
+    },
+    {
+      "shortName": "systemexit",
+      "button": "System.exit",
+      "message": "System.exit sollte nicht verwendet werden",
+      "penaltyRule": {
+        "shortName": "thresholdPenalty",
+        "threshold": 1,
+        "penalty": 5.0
+      },
+      "appliesTo": "functionality::quality"
     }
   ]
 }

--- a/src/test/resources/config.json
+++ b/src/test/resources/config.json
@@ -19,6 +19,15 @@
       },
       "negativeLimit": -3,
       "positiveLimit": null
+    },
+    {
+      "shortName": "functionality::oop",
+      "displayName": "Objektorientierung",
+      "additionalDisplayNames": {
+        "en": "Object Orientation"
+      },
+      "negativeLimit": null,
+      "positiveLimit": null
     }
   ],
   "mistakeTypes": [
@@ -107,6 +116,18 @@
         "penalty": 5.0
       },
       "appliesTo": "functionality::quality"
+    },
+    {
+      "shortName": "instanceof",
+      "button": "instanceof",
+      "message": "instanceof sollte nicht verwendet werden",
+      "penaltyRule": {
+        "shortName": "thresholdPenalty",
+        "threshold": 1,
+        "penalty": 5.0,
+        "repetitions": 3
+      },
+      "appliesTo": "functionality::oop"
     }
   ]
 }


### PR DESCRIPTION
This PR was quite complicated to implement, because of how much internals were exposed by the mistake type.

The original motivation was to allow grouping buttons, and this is what this PR implements.
With this, it is possible to define subgroups, for example:
```json
{
  "shortName": "E2E",
  "positiveFeedbackAllowed": true,
  "ratingGroups": [
    {
      "shortName": "modelling",
      "displayName": "Modellierung",
      "additionalDisplayNames": {
        "en": "Modelling"
      },
      "negativeLimit": -8,
      "positiveLimit": null
    },
    {
      "shortName": "modelling::housekeeping",
      "displayName": "Code Ordnung",
      "additionalDisplayNames": {
        "en": "Housekeeping"
      },
      "negativeLimit": -3,
      "positiveLimit": null
    }
  ],
  "mistakeTypes": [
    {
      "shortName": "custom",
      "button": "Custom Penalty",
      "message": "",
      "penaltyRule": {
        "shortName": "customPenalty"
      },
      "appliesTo": "modelling"
    },
    {
      "shortName": "jdTrivial",
      "button": "JavaDoc Trivial",
      "message": "JavaDoc beschreibt nur triviales und die Fehlerfälle werden nicht beachtet",
      "penaltyRule": {
        "shortName": "thresholdPenalty",
        "threshold": 1,
        "penalty": 5
      },
      "appliesTo": "modelling"
    },
    {
      "shortName": "unused",
      "button": "Unused Element",
      "message": "Das Element wird nicht verwendet",
      "penaltyRule": {
        "shortName": "thresholdPenalty",
        "threshold": 1,
        "penalty": 1.0
      },
      "appliesTo": "modelling::housekeeping"
    },
    {
      "shortName": "visibility",
      "button": "Sichtbarkeit",
      "message": "Die Sichtbarkeit ist nicht korrekt",
      "penaltyRule": {
        "shortName": "thresholdPenalty",
        "threshold": 1,
        "penalty": 0.5
      },
      "appliesTo": "modelling::housekeeping"
    }
  ]
}
```
Here we have the main group `modelling`, and the subgroup `housekeeping`.

`intelligrade` can use this to group the buttons better, which should improve finding buttons in the list.

The scoring has been adapted to work correctly with subgroups:
1. If no limit is specified, it will be inherited from the parent group.
2. If the limits are greater/smaller than the ones defined by the parent, an exception will be raised
3. If a limit is defined that differs from the parent one (like `-3` and `-8` in the parent), all annotations of that subgroup are limited by the limit defined in that subgroup. All points subtracted by the mistake types of that subgroup would then be limited to at most `-3` points.

I wrote a few test cases to ensure that this is correctly implemented.

### API changes

I had to adjust the following methods to make them behave correctly with subgroups. The following methods might cause problems in libraries that use `artemis4j`:
- `MistakeType#getRatingGroup`: This returns the rating group for a mistake type. For mistake types that are associated with a subgroup, this will return the subgroup. Might cause problems, but not sure. The current implementation seems right to me, and it would be confusing to return the parent of the subgroup here.
- `RatingGroup#getMistakeTypes`: This has been renamed to `RatingGroup#getAllMistakeTypes` and adapted, so it will return all mistake types, including the ones associated with a subgroup.

