### PR TITLE
Remove all uses of `defaultValue` property does not set a default value

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/GradingConfig.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/GradingConfig.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.kit.kastel.sdq.artemis4j.grading.ProgrammingExercise;
@@ -112,7 +111,7 @@ public final class GradingConfig {
 
     public record GradingConfigDTO(
             String shortName,
-            @JsonProperty(defaultValue = "true") boolean positiveFeedbackAllowed,
+            Boolean positiveFeedbackAllowed,
             List<Long> allowedExercises,
             List<RatingGroup.RatingGroupDTO> ratingGroups,
             List<MistakeType.MistakeTypeDTO> mistakeTypes) {
@@ -121,6 +120,12 @@ public final class GradingConfig {
             return this.allowedExercises() == null
                     || this.allowedExercises().isEmpty()
                     || this.allowedExercises().contains(exerciseId);
+        }
+
+        @Override
+        public Boolean positiveFeedbackAllowed() {
+            // allow positive feedback if nothing is specified
+            return this.positiveFeedbackAllowed == null || this.positiveFeedbackAllowed;
         }
     }
 }

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/MistakeType.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/MistakeType.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import edu.kit.kastel.sdq.artemis4j.i18n.FormatString;
 import edu.kit.kastel.sdq.artemis4j.i18n.TranslatableString;
@@ -162,5 +161,5 @@ public final class MistakeType {
             Map<String, String> additionalButtonTexts,
             Map<String, String> additionalMessages,
             List<String> autograderProblemTypes,
-            @JsonProperty(defaultValue = "Highlight.DEFAULT") Highlight highlight) {}
+            Highlight highlight) {}
 }

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/ThresholdPenaltyRule.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/penalty/ThresholdPenaltyRule.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.artemis4j.grading.penalty;
 
 import java.util.List;
@@ -17,7 +17,7 @@ public final class ThresholdPenaltyRule implements PenaltyRule {
     public ThresholdPenaltyRule(
             @JsonProperty("threshold") int threshold,
             @JsonProperty(value = "penalty", required = true) double penalty,
-            @JsonProperty(value = "repetitions", defaultValue = "1") Integer repetitions) {
+            @JsonProperty("repetitions") Integer repetitions) {
         this.threshold = threshold;
         // It is not defined how the code should behave if the threshold is 0 or negative, therefore an exception is
         // thrown here.

--- a/src/test/java/edu/kit/kastel/sdq/artemis4j/End2EndTest.java
+++ b/src/test/java/edu/kit/kastel/sdq/artemis4j/End2EndTest.java
@@ -2,6 +2,7 @@
 package edu.kit.kastel.sdq.artemis4j;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -457,5 +458,24 @@ class End2EndTest {
                         "        * src/edu/kit/informatik/InsertionSort.java at line 6",
                         "        * src/edu/kit/informatik/RadixSort.java at lines 4, 5, 6"),
                 globalFeedbackLines);
+    }
+
+    /**
+     * This attribute is important to be set correctly. This test is to ensure that this works as expected.
+     *
+     * @throws ArtemisClientException if a problem with artemis occurs
+     */
+    @Test
+    void testPositiveFeedbackAllowedByDefault() throws ArtemisClientException {
+        var gradingConfig = GradingConfig.readDTOFromString(
+                """
+            {
+                "shortName": "E2E",
+                "ratingGroups": [],
+                "mistakeTypes": []
+            }
+            """);
+
+        assertTrue(gradingConfig.positiveFeedbackAllowed());
     }
 }

--- a/src/test/java/edu/kit/kastel/sdq/artemis4j/End2EndTest.java
+++ b/src/test/java/edu/kit/kastel/sdq/artemis4j/End2EndTest.java
@@ -467,7 +467,7 @@ class End2EndTest {
      */
     @Test
     void testPositiveFeedbackAllowedByDefault() throws ArtemisClientException {
-        var gradingConfig = GradingConfig.readDTOFromString(
+        var minimalGradingConfig = GradingConfig.readDTOFromString(
                 """
             {
                 "shortName": "E2E",
@@ -476,6 +476,6 @@ class End2EndTest {
             }
             """);
 
-        assertTrue(gradingConfig.positiveFeedbackAllowed());
+        assertTrue(minimalGradingConfig.positiveFeedbackAllowed());
     }
 }


### PR DESCRIPTION
Resulted in unnecessary confusion, which is why I removed any use of this in the codebase.

The confusion was, because the property does not do anything, it is only there for "documentation".