### PR TITLE
Update autograder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <spotless.version>3.0.0</spotless.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <autograder.version>0.7.0</autograder.version>
+    <autograder.version>0.8.0</autograder.version>
     <jgit.version>7.4.0.202509020913-r</jgit.version>
     <junit.version>6.0.0</junit.version>
     <archunit.version>1.4.1</archunit.version>


### PR DESCRIPTION
This adds a new method that calls a consumer when a check fails. This will be useful in cases where crashes (-> no annotations by the autograder) are unacceptable.