### PR TITLE
Update to java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <spotless.version>3.5.0</spotless.version>
     <slf4j.version>2.0.18</slf4j.version>
-    <autograder.version>0.8.4</autograder.version>
+    <autograder.version>0.8.5</autograder.version>
     <jgit.version>7.6.0.202603022253-r</jgit.version>
     <junit.version>6.1.0-RC1</junit.version>
     <archunit.version>1.4.2</archunit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
   </distributionManagement>
 
   <properties>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.source>25</maven.compiler.source>
+    <maven.compiler.target>25</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <spotless.version>3.5.0</spotless.version>

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/autograder/AutograderRunner.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/autograder/AutograderRunner.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024-2025. */
+/* Licensed under EPL-2.0 2024-2026. */
 package edu.kit.kastel.sdq.artemis4j.grading.autograder;
 
 import java.io.IOException;
@@ -78,7 +78,7 @@ public final class AutograderRunner {
 
             var problems = autograder.checkFileFallible(
                     submission.getSubmissionSourcePath(),
-                    JavaVersion.JAVA_21,
+                    JavaVersion.latest(),
                     checkConfiguration,
                     statusConsumerWrapper,
                     failureConsumer);


### PR DESCRIPTION
Technically I only need to make artemis4j instruct the autograder to use java 25. If not desired, I can remove the source/compilation target version bump.