### PR TITLE
Track user login in annotations instead of user ids

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Annotation.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Annotation.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024-2025. */
+/* Licensed under EPL-2.0 2024-2026. */
 package edu.kit.kastel.sdq.artemis4j.grading;
 
 import java.util.ArrayList;
@@ -28,8 +28,8 @@ public final class Annotation {
     private final MistakeType type;
     private final Location location;
     private final AnnotationSource source;
-    private final @Nullable Long createdByUserId; // null -> unknown creator
-    private @Nullable Long suppressedByUserId; // null -> not suppressed
+    private final @Nullable UserIdentifier createdByUser; // null -> unknown creator
+    private @Nullable UserIdentifier suppressedByUser; // null -> not suppressed
     private @Nullable String customMessage;
     private @Nullable Double customScore;
     // If not empty, this list contains classifiers that are used to group annotations.
@@ -56,8 +56,9 @@ public final class Annotation {
         this.customScore = dto.customPenaltyForJSON();
         this.classifiers = dto.classifiers() != null ? dto.classifiers() : List.of();
         this.annotationLimit = dto.annotationLimit();
-        this.createdByUserId = dto.createdByUserId();
-        this.suppressedByUserId = dto.suppressedByUserId();
+        this.createdByUser = dto.createdByUserLogin() == null ? null : new UserIdentifier(dto.createdByUserLogin());
+        this.suppressedByUser =
+                dto.suppressedByUserLogin() == null ? null : new UserIdentifier(dto.suppressedByUserLogin());
     }
 
     Annotation(
@@ -66,8 +67,8 @@ public final class Annotation {
             @Nullable String customMessage,
             @Nullable Double customScore,
             AnnotationSource source,
-            @Nullable Long createdByUserId) {
-        this(mistakeType, location, customMessage, customScore, source, createdByUserId, List.of(), null);
+            @Nullable UserIdentifier createdByUser) {
+        this(mistakeType, location, customMessage, customScore, source, createdByUser, List.of(), null);
     }
 
     Annotation(
@@ -76,7 +77,7 @@ public final class Annotation {
             @Nullable String customMessage,
             @Nullable Double customScore,
             AnnotationSource source,
-            @Nullable Long createdByUserId,
+            @Nullable UserIdentifier createdByUser,
             List<String> classifiers,
             @Nullable Integer annotationLimit) {
         // Validate custom penalty and message
@@ -91,8 +92,8 @@ public final class Annotation {
             throw new IllegalArgumentException("A custom penalty is not allowed for non-custom annotation types.");
         }
 
-        if (createdByUserId == null) {
-            log.warn("Creator user id is null, this annotation will not be associated with a user.");
+        if (createdByUser == null) {
+            log.warn("Creator user login is null, this annotation will not be associated with a user.");
         }
 
         this.uuid = generateUUID();
@@ -101,8 +102,8 @@ public final class Annotation {
         this.customMessage = customMessage;
         this.customScore = customScore;
         this.source = source;
-        this.createdByUserId = createdByUserId;
-        this.suppressedByUserId = null; // Not suppressed
+        this.createdByUser = createdByUser;
+        this.suppressedByUser = null; // Not suppressed
         this.classifiers = new ArrayList<>(classifiers);
         this.annotationLimit = annotationLimit;
     }
@@ -228,24 +229,24 @@ public final class Annotation {
         return source;
     }
 
-    public Optional<Long> getCreatorId() {
-        return Optional.ofNullable(createdByUserId);
+    public Optional<UserIdentifier> getCreator() {
+        return Optional.ofNullable(this.createdByUser);
     }
 
-    public void suppress(long userId) {
-        this.suppressedByUserId = userId;
+    public void suppress(UserIdentifier suppressedByUser) {
+        this.suppressedByUser = suppressedByUser;
     }
 
     public void unsuppress() {
-        this.suppressedByUserId = null;
+        this.suppressedByUser = null;
     }
 
     public boolean isSuppressed() {
-        return this.suppressedByUserId != null;
+        return this.suppressedByUser != null;
     }
 
-    public Optional<Long> getSuppressorId() {
-        return Optional.ofNullable(suppressedByUserId);
+    public Optional<UserIdentifier> getSuppressor() {
+        return Optional.ofNullable(this.suppressedByUser);
     }
 
     /**
@@ -263,8 +264,10 @@ public final class Annotation {
                 source,
                 classifiers,
                 annotationLimit,
-                createdByUserId,
-                suppressedByUserId);
+                null,
+                this.getCreator().map(UserIdentifier::login).orElse(null),
+                null,
+                this.getSuppressor().map(UserIdentifier::login).orElse(null));
     }
 
     @Override

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/AnnotationMerger.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/AnnotationMerger.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024-2025. */
+/* Licensed under EPL-2.0 2024-2026. */
 package edu.kit.kastel.sdq.artemis4j.grading;
 
 import java.text.MessageFormat;
@@ -130,7 +130,7 @@ final class AnnotationMerger {
                 customMessage,
                 firstAnnotation.getCustomScore().orElse(null),
                 firstAnnotation.getSource(),
-                firstAnnotation.getCreatorId().orElse(null)));
+                firstAnnotation.getCreator().orElse(null)));
 
         return result;
     }

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/ArtemisConnection.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/ArtemisConnection.java
@@ -101,6 +101,10 @@ public final class ArtemisConnection {
                 .toList();
     }
 
+    public Optional<User> findUserByUserIdentifier(UserIdentifier identifier) throws ArtemisNetworkException {
+        return this.findUserByLogin(identifier.login());
+    }
+
     /**
      * Finds a user based on their login name.
      *

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Assessment.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Assessment.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024-2025. */
+/* Licensed under EPL-2.0 2024-2026. */
 package edu.kit.kastel.sdq.artemis4j.grading;
 
 import java.text.MessageFormat;
@@ -89,7 +89,7 @@ public class Assessment extends ArtemisConnectionHolder {
     private final GradingConfig config;
     private final CorrectionRound correctionRound;
     private final Locale studentLocale;
-    private final long assessorId;
+    private final UserIdentifier assessor;
 
     public Assessment(
             ResultDTO result,
@@ -126,7 +126,7 @@ public class Assessment extends ArtemisConnectionHolder {
             throw new IllegalArgumentException("Can't use a review config for a non-review round");
         }
 
-        this.assessorId = getConnection().getAssessor().getId();
+        this.assessor = this.getConnection().getAssessor().getUserIdentifier();
 
         // ensure that the feedbacks are fetched (some api endpoints do not return them)
         // and for long feedbacks, we need to fetch the detailed feedbacks
@@ -281,7 +281,7 @@ public class Assessment extends ArtemisConnectionHolder {
         }
 
         var source = this.correctionRound.toAnnotationSource();
-        var annotation = new Annotation(mistakeType, location, customMessage, null, source, this.assessorId);
+        var annotation = new Annotation(mistakeType, location, customMessage, null, source, this.assessor);
         this.annotations.add(annotation);
         return annotation;
     }
@@ -325,7 +325,7 @@ public class Assessment extends ArtemisConnectionHolder {
         }
 
         var source = this.correctionRound.toAnnotationSource();
-        var annotation = new Annotation(mistakeType, location, customMessage, customScore, source, this.assessorId);
+        var annotation = new Annotation(mistakeType, location, customMessage, customScore, source, this.assessor);
         this.annotations.add(annotation);
         return annotation;
     }
@@ -348,7 +348,7 @@ public class Assessment extends ArtemisConnectionHolder {
                 explanation,
                 customScore,
                 AnnotationSource.AUTOGRADER,
-                this.assessorId,
+                this.assessor,
                 List.of(checkName, problemType),
                 annotationLimit);
         this.annotations.add(annotation);
@@ -377,7 +377,7 @@ public class Assessment extends ArtemisConnectionHolder {
             throw new ReviewException("Can only suppress annotations in review mode");
         }
 
-        annotation.suppress(this.assessorId);
+        annotation.suppress(this.assessor);
     }
 
     /**

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Course.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/Course.java
@@ -97,6 +97,10 @@ public class Course extends ArtemisConnectionHolder {
                 .orElse(Set.of());
     }
 
+    public Set<CourseRole> getRoles(UserIdentifier userIdentifier) throws ArtemisNetworkException {
+        return this.getRoles(userIdentifier.login());
+    }
+
     public Optional<User> findUserByLogin(String login) throws ArtemisNetworkException {
         var currentUser = this.getConnection().getAssessor();
         if (login.equals(currentUser.getLogin())) {
@@ -110,6 +114,10 @@ public class Course extends ArtemisConnectionHolder {
         }
 
         return Optional.empty();
+    }
+
+    public Optional<User> findUserByUserIdentifier(UserIdentifier userIdentifier) throws ArtemisNetworkException {
+        return this.findUserByLogin(userIdentifier.login());
     }
 
     /**

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/User.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/User.java
@@ -27,6 +27,10 @@ public class User {
         return this.dto.login();
     }
 
+    public UserIdentifier getUserIdentifier() {
+        return new UserIdentifier(this.getLogin());
+    }
+
     public @Nullable String getLangKey() {
         return this.dto.langKey();
     }

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/UserIdentifier.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/UserIdentifier.java
@@ -1,0 +1,49 @@
+/* Licensed under EPL-2.0 2026. */
+package edu.kit.kastel.sdq.artemis4j.grading;
+
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents an identifier to uniquely identify an artemis user.
+ */
+public final class UserIdentifier {
+    private final String login;
+
+    // This constructor and the login are non-public, to prevent
+    // artemis4j users from depending on this information.
+    //
+    // This should reduce breakage in case the identifier has to
+    // be changed again in a future version.
+    UserIdentifier(String login) {
+        this.login = Objects.requireNonNull(login);
+    }
+
+    String login() {
+        return this.login;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (other == null || other.getClass() != this.getClass()) {
+            return false;
+        }
+
+        return ((UserIdentifier) other).login().equals(this.login());
+    }
+
+    @Override
+    public int hashCode() {
+        return this.login().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return this.login();
+    }
+}

--- a/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/metajson/AnnotationDTO.java
+++ b/src/main/java/edu/kit/kastel/sdq/artemis4j/grading/metajson/AnnotationDTO.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024-2025. */
+/* Licensed under EPL-2.0 2024-2026. */
 package edu.kit.kastel.sdq.artemis4j.grading.metajson;
 
 import java.util.List;
@@ -23,5 +23,13 @@ public record AnnotationDTO(
         @JsonProperty @Nullable AnnotationSource source,
         @JsonProperty @Nullable List<String> classifiers,
         @JsonProperty @Nullable Integer annotationLimit,
-        @JsonProperty @Nullable Long createdByUserId,
-        @JsonProperty @Nullable Long suppressedByUserId) {}
+
+        @Deprecated(forRemoval = true) @JsonProperty @Nullable
+        Long createdByUserId,
+
+        @JsonProperty @Nullable String createdByUserLogin,
+
+        @Deprecated(forRemoval = true) @JsonProperty @Nullable
+        Long suppressedByUserId,
+
+        @JsonProperty @Nullable String suppressedByUserLogin) {}

--- a/src/test/java/edu/kit/kastel/sdq/artemis4j/ReviewTest.java
+++ b/src/test/java/edu/kit/kastel/sdq/artemis4j/ReviewTest.java
@@ -90,7 +90,8 @@ class ReviewTest {
         // Assessor tracking
         for (var annotation : annotations) {
             assertEquals(
-                    connection.getAssessor().getId(), annotation.getCreatorId().orElseThrow());
+                    connection.getAssessor().getUserIdentifier(),
+                    annotation.getCreator().orElseThrow());
         }
 
         assertEquals(-3.0, reviewAssessment.calculateTotalPointsOfAnnotations());
@@ -98,15 +99,15 @@ class ReviewTest {
         // Suppression
         reviewAssessment.suppressAnnotation(annotations.getFirst());
         assertEquals(
-                connection.getAssessor().getId(),
-                annotations.getFirst().getSuppressorId().orElseThrow());
+                connection.getAssessor().getUserIdentifier(),
+                annotations.getFirst().getSuppressor().orElseThrow());
         assertEquals(-1.0, reviewAssessment.calculateTotalPointsOfAnnotations());
         assertEquals(1, reviewAssessment.getAnnotations().size());
         assertEquals(2, reviewAssessment.getAnnotations(true).size());
 
         // Unsuppression
         reviewAssessment.unsuppressAnnotation(annotations.getFirst());
-        assertEquals(Optional.empty(), annotations.getFirst().getSuppressorId());
+        assertEquals(Optional.empty(), annotations.getFirst().getSuppressor());
         assertEquals(-3.0, reviewAssessment.calculateTotalPointsOfAnnotations());
         assertEquals(2, reviewAssessment.getAnnotations().size());
         assertEquals(2, reviewAssessment.getAnnotations(true).size());
@@ -123,9 +124,9 @@ class ReviewTest {
         annotations = reviewAssessment.getAnnotations(true);
         assertEquals(2, annotations.size());
         assertEquals(
-                connection.getAssessor().getId(),
-                annotations.getFirst().getSuppressorId().orElseThrow());
-        assertEquals(Optional.empty(), annotations.get(1).getSuppressorId());
+                connection.getAssessor().getUserIdentifier(),
+                annotations.getFirst().getSuppressor().orElseThrow());
+        assertEquals(Optional.empty(), annotations.get(1).getSuppressor());
         assertEquals(-1.0, reviewAssessment.calculateTotalPointsOfAnnotations());
     }
 


### PR DESCRIPTION
These are used to identify who has created or suppressed an annotation. The problem is that artemis does not allow a user id to be resolved to a user for anyone other than an admin. There are some hacks to work around this issue, but they incur a performance hit. It is better to migrate to user login, which is much more useful. This should later resolve the delay when accessing the debug info for the first time in intelligrade.

The UserIdentifier is a wrapper, hopefully making the migration less painful for downstream users if the login must be changed again in the future.